### PR TITLE
Agrega entidad `rol`

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,7 +11,7 @@ export const DatabaseConstants = {
   },
 }
 
-export const ALL_ROLES = [
+export const ALL_PERMISSIONS = [
   'view_home',
   'view_user',
   'edit_user',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -11,6 +11,19 @@ export const DatabaseConstants = {
   },
 }
 
+/**
+  * Lista de permisos que podemos setear en un rol. Esto podria vivir
+  * en el/los front tambien. Queremos hacerlo de esta forma para
+  * despues poder asociar un permiso a una serie de acciones posibles.
+  * Si estos permisos fuesen dinamicos despues tendriamos que
+  * agregar algun flujo para asociar esos permisos a acciones posibles
+  * (en ese caso las acciones estarian fixeadas).
+  *
+  * Disclaimer: esto podria centralizarse en algun lugar (back o front) pero
+  * a falta de mejor opcion actualmente vive en ambos (backoffice + aca).
+  *
+  */
+
 export const ALL_PERMISSIONS = [
   'view_home',
   'view_user',

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,3 +10,10 @@ export const DatabaseConstants = {
     ROLE: 'roles',
   },
 }
+
+export const ALL_ROLES = [
+  'view_home',
+  'view_user',
+  'edit_user',
+  'edit_subject'
+];

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,5 +7,6 @@ export const DatabaseConstants = {
     SUBJECT: 'subjects',
     COURSE: 'courses',
     USER: 'users',
+    ROLE: 'roles',
   },
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,6 +4,7 @@ import CourseModel from './lib/course/adminCourse';
 import SubjectModel from './lib/subject/subjectModel';
 import AdminModel from './lib/adminUser/adminModel';
 import UserModel from './lib/user/userModel';
+import RoleModel from './lib/role/roleModel';
 
 const DB_URL = process.env.DB_URL || 'postgres://postgres@localhost:5432/teachhub';
 
@@ -16,7 +17,8 @@ const initializeDB = () => {
     CourseModel,
     SubjectModel,
     AdminModel,
-    UserModel
+    UserModel,
+    RoleModel,
   }
 
   // Esta magia inicializa los modelos de la base de datos. Basicamente

--- a/src/db/deploy/create_roles_table.sql
+++ b/src/db/deploy/create_roles_table.sql
@@ -5,7 +5,7 @@ BEGIN;
   CREATE TABLE teachhub.roles (
     id                    SERIAL PRIMARY KEY,
     name                  TEXT NOT NULL,
-    parent_role_id        INTEGER,
+    parent_role_id        INTEGER REFERENCES teachhub.roles(id),
     permissions           TEXT NOT NULL,
     active                BOOLEAN DEFAULT false
   );

--- a/src/db/deploy/create_roles_table.sql
+++ b/src/db/deploy/create_roles_table.sql
@@ -1,0 +1,13 @@
+-- Deploy teachhub:create_roles_table to pg
+
+BEGIN;
+
+  CREATE TABLE teachhub.roles (
+    id                    SERIAL PRIMARY KEY,
+    name                  TEXT NOT NULL,
+    parent_role_id        INTEGER,
+    permissions           TEXT NOT NULL,
+    active                BOOLEAN DEFAULT false
+  );
+
+COMMIT;

--- a/src/db/revert/create_roles_table.sql
+++ b/src/db/revert/create_roles_table.sql
@@ -1,0 +1,7 @@
+-- Revert teachhub:create_roles_table from pg
+
+BEGIN;
+
+  DROP TABLE teachhub.roles;
+
+COMMIT;

--- a/src/db/sqitch.plan
+++ b/src/db/sqitch.plan
@@ -6,3 +6,4 @@ create_subjects_table 2022-10-25T03:18:45Z Tomas Lopez Hidalgo <tflopez@fi.uba.a
 create_course_table 2022-11-06T18:10:07Z Tomas Lopez Hidalgo <ttflopez@fi.uba.ar> # Tablas de catedra
 create_admin_users_table 2022-11-08T00:38:27Z Sebastian Penna <spenna@fi.uba.ar> # Create admin users table
 create_users_table 2022-11-09T23:29:58Z Tomas Lopez Hidalgo <tlopez.contractor@lattice.com> # Agrega tabla usuarios
+create_roles_table 2022-11-08T04:07:33Z Tomas Lopez Hidalgo <tlopez.contractor@lattice.com> # Agrega tabla de roles

--- a/src/db/verify/create_roles_table.sql
+++ b/src/db/verify/create_roles_table.sql
@@ -1,0 +1,13 @@
+-- Verify teachhub:create_roles_table on pg
+
+BEGIN;
+
+  SELECT
+    id,
+    name,
+    parent_role_id,
+    permissions,
+    active
+  FROM teachhub.roles;
+
+ROLLBACK;

--- a/src/graphql/adminSchema.ts
+++ b/src/graphql/adminSchema.ts
@@ -4,6 +4,7 @@ import { subjectFields, subjectMutations } from '../lib/subject/graphql';
 import { courseFields, courseMutations } from '../lib/course/graphql';
 import { adminUserFields, adminUserMutations } from '../lib/adminUser/graphql';
 import { userFields, userMutations } from '../lib/user/graphql';
+import { roleFields, roleMutations } from '../lib/role/graphql';
 
 const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -13,7 +14,8 @@ const schema = new GraphQLSchema({
       ...subjectFields,
       ...courseFields,
       ...adminUserFields,
-      ...userFields
+      ...userFields,
+      ...roleFields
     },
   }),
   mutation: new GraphQLObjectType({
@@ -23,7 +25,8 @@ const schema = new GraphQLSchema({
       ...subjectMutations,
       ...courseMutations,
       ...adminUserMutations,
-      ...userMutations
+      ...userMutations,
+      ...roleMutations
     }
   })
 });

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLInt } from 'graphql';
+import { GraphQLString, GraphQLInt, GraphQLNonNull } from 'graphql';
 
 const RAArgs = {
   page: { type: GraphQLInt },

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -1,0 +1,92 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLID,
+  GraphQLBoolean,
+  Source
+} from 'graphql';
+
+const RoleType = new GraphQLObjectType({
+  name: 'Role',
+  description: 'A role within TeachHub',
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    organization: { type: GraphQLString },
+    period: { type: GraphQLString },
+    year: { type: GraphQLInt },
+    subjectId: { type: GraphQLInt },
+    active: { type: GraphQLBoolean }
+  }
+});
+
+const roleFields = {
+  Role: {
+    type: RoleType,
+    args: { id: { type: GraphQLID }},
+    resolve: async (_: Source, { id }: any) => findRole({ roleId: id }),
+  },
+  allRoles: {
+    type: new GraphQLList(RoleType),
+    description: "List of roles on the whole application",
+    args: RAArgs,
+    resolve: async (_: Source, { page, perPage, sortField, sortOrder }: any) => {
+      return findAllRoles({ page, perPage, sortField, sortOrder });
+    }
+  },
+  _allRolesMeta: {
+    type: new GraphQLObjectType({
+      name: 'RoleListMetadata',
+      fields: { count: { type: GraphQLInt }}
+    }),
+    args: RAArgs,
+    resolve: async () => {
+      return { count: (await countRoles()) };
+    }
+  }
+};
+
+const roleMutations = {
+  createRole: {
+    type: RoleType, // Output type
+    description: 'Creates a new role assigning name and department code',
+    args: {
+      name: { type: GraphQLString },
+      organization: { type: GraphQLString },
+      period: { type: GraphQLInt },
+      year: { type: GraphQLInt },
+      subjectId: { type: GraphQLInt }
+    },
+    resolve: async (_: Source, { name, year, period, organization, subjectId }: any) => {
+      console.log("Executing mutation createRole");
+
+      return await createRole({ name, year, period, organization, subjectId });
+    }
+  },
+  updateRole: {
+    type: RoleType,
+    description: 'Update role record on TeachHub',
+    args: {
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      name: { type: new GraphQLNonNull(GraphQLString) },
+      organization: { type: GraphQLString },
+      period: { type: GraphQLInt },
+      year: { type: GraphQLInt },
+      subjectId: { type: GraphQLInt },
+      active: { type: GraphQLBoolean }
+    },
+    resolve: async (_: Source, { id, ...rest }: any) => {
+      console.log("Executing mutation updateRole");
+
+      return updateRole(id, rest)
+    },
+  }
+};
+
+export {
+  roleMutations,
+  roleFields
+}

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -17,7 +17,6 @@ import {
   countRoles,
 } from './roleService';
 
-import { ALL_PERMISSIONS } from '../../consts';
 import { RAArgs } from '../../graphql/utils';
 import { OrderingOptions } from '../../utils';
 
@@ -27,16 +26,6 @@ const RoleType = new GraphQLObjectType({
   fields: {
     id: { type: GraphQLID },
     name: { type: GraphQLString },
-
-  /**
-    * (Tomas) Lista de permisos que podemos setear. Esto podria vivir
-    * en el/los front tambien. Queremos hacerlo de esta forma para
-    * despues poder asociar un permiso a una serie de acciones posibles.
-    * Si estos permisos fuesen dinamicos despues tendriamos que
-    * agregar algun flujo para asociar esos permisos a acciones posibles
-    * (en ese caso las acciones estarian fixeadas).
-    */
-    availablePermissions: { type: new GraphQLList(GraphQLString) },
 
   /**
     * Permisos seteados actualmente para este rol
@@ -60,7 +49,6 @@ const roleFields = {
         permissions: found?.permissions,
         parentRoleId: found?.parentRoleId,
         active: found?.active,
-        availablePermissions: ALL_PERMISSIONS,
       }
     },
   },
@@ -78,7 +66,6 @@ const roleFields = {
           permissions: role?.permissions,
           parentRoleId: role?.parentRoleId,
           active: role?.active,
-          availablePermissions: ALL_PERMISSIONS,
         }
       });
     }
@@ -115,7 +102,6 @@ const roleMutations = {
         permissions: newRole?.permissions,
         parentRoleId: newRole?.parentRoleId,
         active: newRole?.active,
-        availablePermissions: ALL_PERMISSIONS,
       };
     }
   },
@@ -140,7 +126,6 @@ const roleMutations = {
         permissions: updated?.permissions,
         parentRoleId: updated?.parentRoleId,
         active: updated?.active,
-        availablePermissions: ALL_PERMISSIONS,
       };
     },
   }

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -2,12 +2,22 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLList,
-  GraphQLNonNull,
   GraphQLInt,
   GraphQLID,
   GraphQLBoolean,
   Source
 } from 'graphql';
+
+import {
+  createRole,
+  findAllRoles,
+  findRole,
+  updateRole,
+  countRoles,
+} from './roleService';
+
+import { ALL_ROLES } from '../../consts';
+import { RAArgs } from '../../graphql/utils';
 
 const RoleType = new GraphQLObjectType({
   name: 'Role',
@@ -15,11 +25,23 @@ const RoleType = new GraphQLObjectType({
   fields: {
     id: { type: GraphQLID },
     name: { type: GraphQLString },
-    organization: { type: GraphQLString },
-    period: { type: GraphQLString },
-    year: { type: GraphQLInt },
-    subjectId: { type: GraphQLInt },
-    active: { type: GraphQLBoolean }
+
+  /**
+    * (Tomas) Lista de permisos que podemos setear. Esto podria vivir
+    * en el/los front tambien. Queremos hacerlo de esta forma para
+    * despues poder asociar un permiso a una serie de acciones posibles.
+    * Si estos permisos fuesen dinamicos despues tendriamos que
+    * agregar algun flujo para asociar esos permisos a acciones posibles
+    * (en ese caso las acciones estarian fixeadas).
+    */
+    availablePermissions: { type: new GraphQLList(GraphQLString) },
+
+  /**
+    * Permisos seteados actualmente para este rol
+    */
+    permissions: { type: GraphQLString },
+    parentRoleId: { type: GraphQLString },
+    active: { type: GraphQLBoolean },
   }
 });
 
@@ -51,32 +73,30 @@ const roleFields = {
 
 const roleMutations = {
   createRole: {
-    type: RoleType, // Output type
-    description: 'Creates a new role assigning name and department code',
+    type: RoleType,
+    description: 'Creates a new role',
     args: {
       name: { type: GraphQLString },
-      organization: { type: GraphQLString },
-      period: { type: GraphQLInt },
-      year: { type: GraphQLInt },
-      subjectId: { type: GraphQLInt }
+      permissions: { type: new GraphQLList(GraphQLString) },
+      parentRoleId: { type: GraphQLID },
     },
-    resolve: async (_: Source, { name, year, period, organization, subjectId }: any) => {
+    resolve: async (_: Source, { name, permissions, parentRoleId }: any) => {
       console.log("Executing mutation createRole");
 
-      return await createRole({ name, year, period, organization, subjectId });
+      const newRole = await createRole({ name, permissions, parentRoleId });
+
+      return ;
     }
   },
   updateRole: {
     type: RoleType,
     description: 'Update role record on TeachHub',
     args: {
-      id: { type: new GraphQLNonNull(GraphQLID) },
-      name: { type: new GraphQLNonNull(GraphQLString) },
-      organization: { type: GraphQLString },
-      period: { type: GraphQLInt },
-      year: { type: GraphQLInt },
-      subjectId: { type: GraphQLInt },
-      active: { type: GraphQLBoolean }
+      id: { type: GraphQLID },
+      name: { type: GraphQLString },
+      permissions: { type: GraphQLString },
+      parentRoleId: { type: GraphQLID },
+      active: { type: GraphQLBoolean },
     },
     resolve: async (_: Source, { id, ...rest }: any) => {
       console.log("Executing mutation updateRole");

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -30,7 +30,7 @@ const RoleType = new GraphQLObjectType({
   /**
     * Permisos seteados actualmente para este rol
     */
-    permissions: { type: GraphQLString },
+    permissions: { type: new GraphQLList(GraphQLString) },
     parentRoleId: { type: GraphQLString },
     active: { type: GraphQLBoolean },
   }
@@ -111,7 +111,7 @@ const roleMutations = {
     args: {
       id: { type: GraphQLID },
       name: { type: GraphQLString },
-      permissions: { type: GraphQLString },
+      permissions: { type: new GraphQLList(GraphQLString) },
       parentRoleId: { type: GraphQLID },
       active: { type: GraphQLBoolean },
     },

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -41,15 +41,7 @@ const roleFields = {
     type: RoleType,
     args: { id: { type: new GraphQLNonNull(GraphQLID) }},
     resolve: async (_: Source, { id }: any) => {
-      const found = await findRole({ roleId: id });
-
-      return {
-        id: found?.id,
-        name: found?.name,
-        permissions: found?.permissions,
-        parentRoleId: found?.parentRoleId,
-        active: found?.active,
-      }
+      return findRole({ roleId: id });
     },
   },
   allRoles: {
@@ -57,17 +49,7 @@ const roleFields = {
     description: "List of roles on the whole application",
     args: RAArgs,
     resolve: async (_: Source, { page, perPage, sortField, sortOrder }: OrderingOptions) => {
-      const allRoles = await findAllRoles({ page, perPage, sortField, sortOrder });
-
-      return allRoles.map(role => {
-        return {
-          id: role?.id,
-          name: role?.name,
-          permissions: role?.permissions,
-          parentRoleId: role?.parentRoleId,
-          active: role?.active,
-        }
-      });
+      return findAllRoles({ page, perPage, sortField, sortOrder });
     }
   },
   _allRolesMeta: {
@@ -77,7 +59,7 @@ const roleFields = {
     }),
     args: RAArgs,
     resolve: async () => {
-      return { count: (await countRoles()) };
+      return countRoles().then(count => ({ count }));
     }
   }
 };
@@ -94,15 +76,7 @@ const roleMutations = {
     resolve: async (_: Source, { name, permissions, parentRoleId }: any) => {
       console.log("Executing mutation createRole");
 
-      const newRole = await createRole({ name, permissions, parentRoleId });
-
-      return {
-        id: newRole?.id,
-        name: newRole?.name,
-        permissions: newRole?.permissions,
-        parentRoleId: newRole?.parentRoleId,
-        active: newRole?.active,
-      };
+      return createRole({ name, permissions, parentRoleId });
     }
   },
   updateRole: {
@@ -118,16 +92,22 @@ const roleMutations = {
     resolve: async (_: Source, { id, ...rest }: any) => {
       console.log("Executing mutation updateRole");
 
-      const updated = await updateRole(id, rest)
-
-      return {
-        id: updated?.id,
-        name: updated?.name,
-        permissions: updated?.permissions,
-        parentRoleId: updated?.parentRoleId,
-        active: updated?.active,
-      };
+      return updateRole(id, rest)
     },
+  },
+  deleteRole: {
+    type: RoleType,
+    args: { id: { type: new GraphQLNonNull(GraphQLID) }},
+    resolve: async (_: Source, { id }: any) => {
+
+      console.log("Would delete role: ", { id })
+
+    /**
+      * (Tomas): No borramos entidades por el momento.
+      */
+
+      return findRole({ roleId: id });
+    }
   }
 };
 

--- a/src/lib/role/roleModel.ts
+++ b/src/lib/role/roleModel.ts
@@ -24,7 +24,6 @@ class Role extends Sequelize.Model {
         parentRoleId: {
           type: Sequelize.NUMBER,
           field: 'parent_role_id',
-          allowNull: false,
         },
         permissions: {
           type: Sequelize.STRING
@@ -44,7 +43,6 @@ class Role extends Sequelize.Model {
   }
 
   static associate = () => {
-    Role.hasOne(Role, { foreignKey: 'parent_role_id' })
   }
 }
 

--- a/src/lib/role/roleModel.ts
+++ b/src/lib/role/roleModel.ts
@@ -1,0 +1,51 @@
+import Sequelize from 'sequelize';
+
+import { DatabaseConstants } from "../../consts";
+
+class Role extends Sequelize.Model {
+  readonly id!: number;
+  readonly name!: string;
+  readonly parentRoleId!: number;
+  readonly permissions!: string;
+  readonly active!: boolean;
+
+  static initialize = (db: Sequelize.Sequelize) => {
+    return Role.init(
+      {
+        id: {
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        name: {
+          type: Sequelize.TEXT,
+          allowNull: false,
+        },
+        parentRoleId: {
+          type: Sequelize.NUMBER,
+          field: 'parent_role_id',
+          allowNull: false,
+        },
+        permissions: {
+          type: Sequelize.STRING
+        },
+        active: {
+          type: Sequelize.BOOLEAN,
+          allowNull: false
+        }
+      },
+      {
+        sequelize: db,
+        schema: DatabaseConstants.SCHEMAS.TEACH_HUB,
+        tableName: DatabaseConstants.TABLES.ROLE,
+        timestamps: false,
+      }
+    );
+  }
+
+  static associate = () => {
+    Role.hasOne(Role, { foreignKey: 'parent_role_id' })
+  }
+}
+
+export default Role;

--- a/src/lib/role/roleService.ts
+++ b/src/lib/role/roleService.ts
@@ -1,0 +1,64 @@
+import Role from './adminRole';
+import { isNumber, OrderingOptions } from '../../utils';
+
+export async function createRole(
+  { organization, name, year, period, subjectId }
+  : { organization: string, name: string, period: Number, year: Number, subjectId: Number }
+) {
+
+  return Role.create({ active: true, githubOrganization: organization, name, year, period, subjectId });
+}
+
+export async function findAllRoles(options: OrderingOptions) {
+
+  const paginationOptions = isNumber(options.perPage) && isNumber(options.page) ?
+    { limit: options.perPage, offset: options.page * options.perPage }
+    : {};
+
+  const orderingOptions = options.sortField ? [[ options.sortField, options.sortOrder?? 'DESC' ]] : [];
+
+  // @ts-expect-error (Tomas): Parece que para tipar esto bien hay que hacer algo como
+  // keyof Role porque Sequelize (sus tipos para se exactos) no entiende
+  // que el primer elemento de la lista en realidad son las keys del modelo.
+
+  return Role.findAll({ ...paginationOptions, order: orderingOptions });
+}
+
+export async function countRoles() { return Role.count({}) };
+
+export async function findRole({ roleId }: { roleId: string }) {
+
+  return Role.findOne({ where: { id: Number(roleId) }});
+}
+
+export async function updateRole(
+  id: string,
+  attrs: {
+    name?: string,
+    organization?: string,
+    subjectId?: number,
+    period?: number,
+    year?: number,
+    active?: boolean,
+  }
+) {
+
+  // https://sequelize.org/api/v6/class/src/model.js~model#static-method-update
+  // `update` devuelve un array con los valores updateados en el segundo lugar.
+  const [_, [updated]] = await Role.update(
+    {
+      name: attrs.name,
+      githubOrganization: attrs.organization,
+      subjectId: attrs.subjectId,
+      period: attrs.period,
+      year: attrs.year,
+      active: attrs.active
+    },
+    {
+      where: { id: Number(id) },
+      returning: true
+    }
+  );
+
+  return updated;
+}

--- a/src/lib/role/roleService.ts
+++ b/src/lib/role/roleService.ts
@@ -2,8 +2,8 @@ import RoleModel from './roleModel';
 import { isNumber, OrderingOptions } from '../../utils';
 import { ALL_PERMISSIONS } from '../../consts';
 
-const encodePermissions = (permissions: string[]): string => permissions.join('.');
-const decodePermissions = (encoded: string): string[] => encoded.split('.');
+const encodePermissions = (permissions: string[]): string => permissions.join(',');
+const decodePermissions = (encoded: string): string[] => encoded.split(',');
 
 const isInvalidPermission = (p: string) => !ALL_PERMISSIONS.includes(p)
 
@@ -13,22 +13,22 @@ export async function createRole(
 ) {
 
   if (permissions.some(isInvalidPermission)) {
-    throw new Error('Invalid permission');
+    throw new Error('Role has invalid permission(s)');
   }
 
   const created = await RoleModel.create({
     name,
     active: true,
     permissions: encodePermissions(permissions),
-    parentRoleId: parentRoleId? Number(parentRoleId): null,
+    parentRoleId: parentRoleId ? Number(parentRoleId): null,
   });
 
   return {
-    id: created?.id,
-    name: created?.name,
-    permissions: decodePermissions(created?.permissions),
-    parentRoleId: created?.parentRoleId,
-    active: created?.active,
+    id: created.id,
+    name: created.name,
+    permissions: decodePermissions(created.permissions),
+    parentRoleId: created.parentRoleId,
+    active: created.active,
   }
 }
 
@@ -87,17 +87,16 @@ export async function updateRole(
   }
 
   if (attrs.permissions.some(isInvalidPermission)) {
-    throw new Error('Invalid permission')
+    throw new Error('Role has invalid permission(s)')
   }
 
-  // TODO.
-  // Validar que no haya ciclos.
+  // TODO. Validar que no haya ciclos.
 
   const [_, [updated]] = await RoleModel.update(
     {
       name: attrs.name,
       permissions: encodePermissions(attrs.permissions),
-      parentRoleId: attrs.parentRoleId? attrs.parentRoleId: null,
+      parentRoleId: attrs.parentRoleId ? attrs.parentRoleId: null,
       active: attrs.active,
     },
     {
@@ -107,11 +106,10 @@ export async function updateRole(
   );
 
   return {
-    id: updated?.id,
-    name: updated?.name,
-    permissions: decodePermissions(updated?.permissions ?? ''),
-    parentRoleId: updated?.parentRoleId,
-    active: updated?.active,
+    id: updated.id,
+    name: updated.name,
+    permissions: decodePermissions(updated.permissions ?? ''),
+    parentRoleId: updated.parentRoleId,
+    active: updated.active,
   }
-
 }


### PR DESCRIPTION
Diseño inicial para roles:

### Cómo lo pense:

 - Los roles le permiten a cierto usuario realizar (o no) acciones, como por ejemplo _ver el perfil de otro usuario_. 
 - Nosotros en algún punto (en el futuro) vamos a querer hacer algo así:
 ```typescript
 if ('view_other_user' in currentUser.role.permissions) {
    return otherUserInfo
 } else {
    return null;
}
 ```

Lo que significa que esa serie de permisos tiene que estar escrita (o mejor dicho **harcodeada** en algún lugar), ya que de otra forma tendríamos que tener algún flujo que asocie acciones a permisos (es decir, permitirle al usuario asociar 'view_other_user' a la acción de _ver el perfil de otro usuario_; esto es tremendamente más complejo y engorroso, así que queda medio fuera de scope. 

Definí una lista inicial que podemos ir haciendo crecer y asociarlas a las acciones a través de código (nosotros sabemos que si la persona tiene `view_other_user` en sus permisos entonces debería poder ver otros perfiles).