### PR TITLE
Usar tipos de librería `graphql` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 sqitch.conf
+.idea

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -14,12 +14,7 @@ type RootQueryType {
   findUser(userId: ID): User
 
   """Logged in user"""
-  viewer(
-    age: Int
-
-    """testing"""
-    name: Int
-  ): User
+  viewer: User
 }
 
 """A non-admin user within TeachHub"""

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -14,7 +14,12 @@ type RootQueryType {
   findUser(userId: ID): User
 
   """Logged in user"""
-  viewer: User
+  viewer(
+    age: Int
+
+    """testing"""
+    name: Int
+  ): User
 }
 
 """A non-admin user within TeachHub"""

--- a/src/graphql/adminSchema.ts
+++ b/src/graphql/adminSchema.ts
@@ -1,4 +1,4 @@
-import { Source, GraphQLSchema, GraphQLObjectType } from 'graphql';
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
 import { subjectFields, subjectMutations } from '../lib/subject/graphql';
 import { courseFields, courseMutations } from '../lib/course/graphql';
@@ -10,7 +10,7 @@ import { userRoleFields, userRoleMutations } from '../lib/userRole/graphql';
 import type { Context } from 'src/types';
 
 const schema = new GraphQLSchema({
-  query: new GraphQLObjectType<Source, Context>({
+  query: new GraphQLObjectType<null, Context>({
     name: 'Query',
     description: 'Admin schema root query',
     fields: {
@@ -22,7 +22,7 @@ const schema = new GraphQLSchema({
       ...userRoleFields,
     },
   }),
-  mutation: new GraphQLObjectType<Source, Context>({
+  mutation: new GraphQLObjectType<null, Context>({
     name: 'Mutation',
     description: 'Admin schema root mutation',
     fields: {

--- a/src/graphql/adminSchema.ts
+++ b/src/graphql/adminSchema.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+import { Source, GraphQLSchema, GraphQLObjectType } from 'graphql';
 
 import { subjectFields, subjectMutations } from '../lib/subject/graphql';
 import { courseFields, courseMutations } from '../lib/course/graphql';
@@ -7,8 +7,10 @@ import { userFields, userMutations } from '../lib/user/graphql';
 import { roleFields, roleMutations } from '../lib/role/graphql';
 import { userRoleFields, userRoleMutations } from '../lib/userRole/graphql';
 
+import type { Context } from 'src/types';
+
 const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
+  query: new GraphQLObjectType<Source, Context>({
     name: 'Query',
     description: 'Admin schema root query',
     fields: {
@@ -20,7 +22,7 @@ const schema = new GraphQLSchema({
       ...userRoleFields,
     },
   }),
-  mutation: new GraphQLObjectType({
+  mutation: new GraphQLObjectType<Source, Context>({
     name: 'Mutation',
     description: 'Admin schema root mutation',
     fields: {

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -1,14 +1,24 @@
-import { GraphQLID, GraphQLInt, GraphQLList, GraphQLObjectType, Source } from 'graphql';
+import {
+  GraphQLOutputType,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigMap,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  Source,
+} from 'graphql';
 
 import { RAArgs } from '../graphql/utils';
 
 import type { OrderingOptions } from 'src/utils';
 import type { IModelFields } from 'src/sequelize/types';
+import type { Context } from 'src/types';
 
 const buildFindTypeObject = (
-  type: GraphQLObjectType,
+  type: GraphQLOutputType,
   findCallback: (id: string) => Promise<IModelFields>
-) => {
+): GraphQLFieldConfig<Source, Context> => {
   return {
     type: type,
     args: { id: { type: GraphQLID } },
@@ -19,10 +29,10 @@ const buildFindTypeObject = (
 };
 
 const buildFindAllTypeObject = (
-  type: GraphQLObjectType,
+  type: GraphQLOutputType,
   typeName: string,
   findAllCallback: (args: OrderingOptions) => Promise<IModelFields[]>
-) => {
+): GraphQLFieldConfig<Source, Context> => {
   return {
     type: new GraphQLList(type),
     description: 'List of ' + typeName + ' on the whole application',
@@ -36,7 +46,10 @@ const buildFindAllTypeObject = (
   };
 };
 
-const buildMetaTypeObject = (keyName: string, countCallback: () => Promise<number>) => {
+const buildMetaTypeObject = (
+  keyName: string,
+  countCallback: () => Promise<number>
+): GraphQLFieldConfig<Source, Context> => {
   return {
     type: new GraphQLObjectType({
       name: keyName + 'ListMetadata',
@@ -50,7 +63,7 @@ const buildMetaTypeObject = (keyName: string, countCallback: () => Promise<numbe
 };
 
 interface FieldParams {
-  type: GraphQLObjectType;
+  type: GraphQLOutputType;
   keyName: string;
   typeName: string;
   countCallback: () => Promise<number>;
@@ -65,7 +78,7 @@ export const buildEntityFields = ({
   countCallback,
   findCallback,
   findAllCallback,
-}: FieldParams) => {
+}: FieldParams): GraphQLFieldConfigMap<Source, Context> => {
   return {
     [keyName]: buildFindTypeObject(type, findCallback),
     [`all${keyName}s`]: buildFindAllTypeObject(type, typeName, findAllCallback),

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -6,7 +6,6 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLObjectType,
-  Source,
 } from 'graphql';
 
 import { RAArgs } from '../graphql/utils';
@@ -18,11 +17,11 @@ import type { Context } from 'src/types';
 const buildFindTypeObject = (
   type: GraphQLOutputType,
   findCallback: (id: string) => Promise<IModelFields>
-): GraphQLFieldConfig<Source, Context> => {
+): GraphQLFieldConfig<unknown, Context> => {
   return {
     type: type,
     args: { id: { type: GraphQLID } },
-    resolve: async (_: Source, { id }: any) => {
+    resolve: async (_: unknown, { id }: any) => {
       return findCallback(id);
     },
   };
@@ -32,13 +31,13 @@ const buildFindAllTypeObject = (
   type: GraphQLOutputType,
   typeName: string,
   findAllCallback: (args: OrderingOptions) => Promise<IModelFields[]>
-): GraphQLFieldConfig<Source, Context> => {
+): GraphQLFieldConfig<unknown, Context> => {
   return {
     type: new GraphQLList(type),
     description: 'List of ' + typeName + ' on the whole application',
     args: RAArgs,
     resolve: async (
-      _: Source,
+      _: unknown,
       { page, perPage, sortField, sortOrder }: OrderingOptions
     ) => {
       return findAllCallback({ page, perPage, sortField, sortOrder });
@@ -49,7 +48,7 @@ const buildFindAllTypeObject = (
 const buildMetaTypeObject = (
   keyName: string,
   countCallback: () => Promise<number>
-): GraphQLFieldConfig<Source, Context> => {
+): GraphQLFieldConfig<unknown, Context> => {
   return {
     type: new GraphQLObjectType({
       name: keyName + 'ListMetadata',
@@ -78,7 +77,7 @@ export const buildEntityFields = ({
   countCallback,
   findCallback,
   findAllCallback,
-}: FieldParams): GraphQLFieldConfigMap<Source, Context> => {
+}: FieldParams): GraphQLFieldConfigMap<unknown, Context> => {
   return {
     [keyName]: buildFindTypeObject(type, findCallback),
     [`all${keyName}s`]: buildFindAllTypeObject(type, typeName, findAllCallback),

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -5,7 +5,6 @@ import {
   GraphQLID,
   GraphQLNonNull,
   GraphQLOutputType,
-  Source,
 } from 'graphql';
 
 import type { Context } from 'src/types';
@@ -16,7 +15,7 @@ const buildCreateTypeMutation = (
   typeName: string,
   fields: GraphQLFieldConfigArgumentMap,
   createCallback: (args: any) => Promise<IModelFields>
-): GraphQLFieldConfig<Source, Context> => ({
+): GraphQLFieldConfig<unknown, Context> => ({
   type,
   description: 'Creates a new ' + typeName,
   args: fields,
@@ -32,7 +31,7 @@ const buildUpdateTypeMutation = (
   typeName: string,
   fields: GraphQLFieldConfigArgumentMap,
   updateCallback: (id: string, args: any) => Promise<IModelFields>
-): GraphQLFieldConfig<Source, Context> => {
+): GraphQLFieldConfig<unknown, Context> => {
   return {
     type: type,
     description: 'Updates a ' + typeName,
@@ -49,11 +48,11 @@ const buildDeleteTypeMutation = (
   type: GraphQLOutputType,
   typeName: string,
   findCallback: (id: string) => Promise<IModelFields>
-): GraphQLFieldConfig<Source, Context> => {
+): GraphQLFieldConfig<unknown, Context> => {
   return {
     type: type,
     args: { id: { type: new GraphQLNonNull(GraphQLID) } },
-    resolve: async (_: Source, { id }: any, ctx: Context) => {
+    resolve: async (_: unknown, { id }: any, ctx: Context) => {
       ctx.logger.info('Would delete ' + typeName + ': ', { id });
 
       // Currently, not deleting entities
@@ -82,7 +81,7 @@ export const buildEntityMutations = <T extends IModelFields>({
   createCallback,
   updateCallback,
   findCallback,
-}: MutationsParams<T>): GraphQLFieldConfigMap<Source, Context> => {
+}: MutationsParams<T>): GraphQLFieldConfigMap<unknown, Context> => {
   return {
     ['create' + keyName]: buildCreateTypeMutation(
       type,

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,11 +1,4 @@
-import {
-  GraphQLFieldConfig,
-  GraphQLFieldConfigArgumentMap,
-  GraphQLSchema,
-  GraphQLObjectType,
-  Source,
-  GraphQLInt,
-} from 'graphql';
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
 import { userMutations, userFields, UserType } from '../lib/user/internalGraphql';
 import { findAllUsers } from '../lib/user/userService';
@@ -33,35 +26,20 @@ const getViewer = async (ctx: Context) => {
   };
 };
 
-const testing: GraphQLFieldConfigArgumentMap = {
-  age: {
-    type: GraphQLInt,
-  },
-  name: {
-    description: 'testing',
-    type: GraphQLInt,
-  },
-};
-
-const x: GraphQLFieldConfig<Source, Context> = {
-  args: testing,
-  description: 'Logged in user',
-  type: UserType,
-  resolve: async (_source, _args, context) => {
-    return getViewer(context);
-  },
-};
-
-const Query: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const Query: GraphQLObjectType<null, Context> = new GraphQLObjectType({
   name: 'RootQueryType',
   description: 'Root query',
   fields: {
-    viewer: x,
+    viewer: {
+      description: 'Logged in user',
+      type: UserType,
+      resolve: async (_source, _args, ctx) => getViewer(ctx),
+    },
     ...userFields,
   },
 });
 
-const Mutation: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const Mutation: GraphQLObjectType<null, Context> = new GraphQLObjectType({
   name: 'RootMutationType',
   description: 'Root mutation',
   fields: {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,4 +1,11 @@
-import { GraphQLSchema, GraphQLObjectType, Source } from 'graphql';
+import {
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLSchema,
+  GraphQLObjectType,
+  Source,
+  GraphQLInt,
+} from 'graphql';
 
 import { userMutations, userFields, UserType } from '../lib/user/internalGraphql';
 import { findAllUsers } from '../lib/user/userService';
@@ -11,7 +18,7 @@ import type { Context } from 'src/types';
  * usuario logeado. Hasta entonces devolvemos simplemente el primer
  * usuario de la base.
  */
-const getViewer = async (source: Source, args: any, ctx: Context) => {
+const getViewer = async (ctx: Context) => {
   const [viewer] = await findAllUsers({});
 
   ctx.logger.info('Using viewer', viewer);
@@ -26,20 +33,35 @@ const getViewer = async (source: Source, args: any, ctx: Context) => {
   };
 };
 
-const Query = new GraphQLObjectType({
+const testing: GraphQLFieldConfigArgumentMap = {
+  age: {
+    type: GraphQLInt,
+  },
+  name: {
+    description: 'testing',
+    type: GraphQLInt,
+  },
+};
+
+const x: GraphQLFieldConfig<Source, Context> = {
+  args: testing,
+  description: 'Logged in user',
+  type: UserType,
+  resolve: async (_source, _args, context) => {
+    return getViewer(context);
+  },
+};
+
+const Query: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'RootQueryType',
   description: 'Root query',
   fields: {
-    viewer: {
-      description: 'Logged in user',
-      type: UserType,
-      resolve: getViewer,
-    },
+    viewer: x,
     ...userFields,
   },
 });
 
-const Mutation = new GraphQLObjectType({
+const Mutation: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'RootMutationType',
   description: 'Root mutation',
   fields: {

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -7,6 +7,7 @@ const RAArgs = {
   sortOrder: { type: GraphQLString },
 };
 
-type GraphqlObjectTypeFields = Record<any, any>;
+// type GraphqlObjectTypeFields = Record<any, any>;
+type GraphqlObjectTypeFields = Record<string, any>;
 
 export { RAArgs, GraphqlObjectTypeFields };

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -7,7 +7,4 @@ const RAArgs = {
   sortOrder: { type: GraphQLString },
 };
 
-// type GraphqlObjectTypeFields = Record<any, any>;
-type GraphqlObjectTypeFields = Record<string, any>;
-
-export { RAArgs, GraphqlObjectTypeFields };
+export { RAArgs };

--- a/src/lib/adminUser/graphql.ts
+++ b/src/lib/adminUser/graphql.ts
@@ -1,9 +1,7 @@
 import {
   GraphQLObjectType,
   GraphQLString,
-  GraphQLList,
   GraphQLNonNull,
-  GraphQLInt,
   GraphQLID,
   Source,
 } from 'graphql';
@@ -15,29 +13,30 @@ import {
   updateAdminUser,
   findAdminUser,
 } from './adminService';
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
+
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (isUpdate: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
+import type { Context } from 'src/types';
+
+const getFields = ({ isUpdate }: { isUpdate: boolean }) => {
+  const fields = {
+    ...(isUpdate
+      ? { id: { type: GraphQLID }, password: { type: new GraphQLNonNull(GraphQLString) } }
+      : {}),
     email: { type: GraphQLString },
     password: { type: GraphQLString },
     name: { type: GraphQLString },
     lastName: { type: GraphQLString },
   };
-  if (isUpdate) {
-    fields.id = { type: GraphQLID };
-    fields.password = { type: new GraphQLNonNull(GraphQLString) };
-  }
 
   return fields;
 };
 
-const AdminUserType = new GraphQLObjectType({
+const AdminUserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'AdminUser',
   description: 'A role within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ isUpdate: true }),
 });
 
 const findAdminUserCallback = (id: string) => {
@@ -57,8 +56,8 @@ const adminUserMutations = buildEntityMutations({
   type: AdminUserType,
   keyName: 'AdminUser',
   typeName: 'admin user',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ isUpdate: false }),
+  updateFields: getFields({ isUpdate: true }),
   createCallback: createAdminUser,
   updateCallback: updateAdminUser,
   findCallback: findAdminUserCallback,

--- a/src/lib/adminUser/graphql.ts
+++ b/src/lib/adminUser/graphql.ts
@@ -52,6 +52,7 @@ const adminUserFields = buildEntityFields({
   findAllCallback: findAllAdminUsers,
   countCallback: countAdminUsers,
 });
+
 const adminUserMutations = buildEntityMutations({
   type: AdminUserType,
   keyName: 'AdminUser',

--- a/src/lib/adminUser/graphql.ts
+++ b/src/lib/adminUser/graphql.ts
@@ -1,10 +1,4 @@
-import {
-  GraphQLObjectType,
-  GraphQLString,
-  GraphQLNonNull,
-  GraphQLID,
-  Source,
-} from 'graphql';
+import { GraphQLObjectType, GraphQLString, GraphQLNonNull, GraphQLID } from 'graphql';
 
 import {
   createAdminUser,
@@ -33,7 +27,7 @@ const getFields = ({ isUpdate }: { isUpdate: boolean }) => {
   return fields;
 };
 
-const AdminUserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const AdminUserType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'AdminUser',
   description: 'A role within TeachHub',
   fields: getFields({ isUpdate: true }),

--- a/src/lib/course/graphql.ts
+++ b/src/lib/course/graphql.ts
@@ -56,6 +56,7 @@ const courseFields = buildEntityFields({
   findAllCallback: findAllCourses,
   countCallback: countCourses,
 });
+
 const courseMutations = buildEntityMutations({
   type: CourseType,
   keyName: 'Course',

--- a/src/lib/course/graphql.ts
+++ b/src/lib/course/graphql.ts
@@ -1,7 +1,6 @@
 import {
   GraphQLObjectType,
   GraphQLString,
-  GraphQLList,
   GraphQLInt,
   GraphQLID,
   GraphQLBoolean,
@@ -17,12 +16,19 @@ import {
   countCourses,
 } from './courseService';
 
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (isUpdate: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
+import type { Context } from 'src/types';
+
+const getFields = ({ isUpdate }: { isUpdate: boolean }) => {
+  const fields = {
+    ...(isUpdate
+      ? {
+          id: { type: new GraphQLNonNull(GraphQLID) },
+          name: { type: new GraphQLNonNull(GraphQLString) },
+        }
+      : {}),
     name: { type: GraphQLString },
     organization: { type: GraphQLString },
     period: { type: GraphQLInt },
@@ -30,18 +36,14 @@ const getFields = (isUpdate: boolean) => {
     subjectId: { type: GraphQLInt },
     active: { type: GraphQLBoolean },
   };
-  if (isUpdate) {
-    fields.id = { type: new GraphQLNonNull(GraphQLID) };
-    fields.name = { type: new GraphQLNonNull(GraphQLString) };
-  }
 
   return fields;
 };
 
-const CourseType = new GraphQLObjectType({
+const CourseType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'Course',
   description: 'A course within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ isUpdate: true }),
 });
 
 const findCourseCallback = (id: string) => {
@@ -61,8 +63,8 @@ const courseMutations = buildEntityMutations({
   type: CourseType,
   keyName: 'Course',
   typeName: 'course',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ isUpdate: false }),
+  updateFields: getFields({ isUpdate: true }),
   createCallback: createCourse,
   updateCallback: updateCourse,
   findCallback: findCourseCallback,

--- a/src/lib/course/graphql.ts
+++ b/src/lib/course/graphql.ts
@@ -5,7 +5,6 @@ import {
   GraphQLID,
   GraphQLBoolean,
   GraphQLNonNull,
-  Source,
 } from 'graphql';
 
 import {
@@ -40,7 +39,7 @@ const getFields = ({ isUpdate }: { isUpdate: boolean }) => {
   return fields;
 };
 
-const CourseType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const CourseType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'Course',
   description: 'A course within TeachHub',
   fields: getFields({ isUpdate: true }),

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -17,18 +17,17 @@ import {
   countRoles,
 } from './roleService';
 
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (addIdd: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
+const getFields = ({ addId }: { addId: boolean }) => {
+  const fields = {
+    ...(addId ? { id: { type: GraphQLID } } : {}),
     name: { type: GraphQLString },
     permissions: { type: new GraphQLList(GraphQLString) },
     parentRoleId: { type: GraphQLID },
     active: { type: GraphQLBoolean },
   };
-  if (addIdd) fields.id = { type: GraphQLID };
 
   return fields;
 };
@@ -36,7 +35,7 @@ const getFields = (addIdd: boolean) => {
 const RoleType = new GraphQLObjectType({
   name: 'Role',
   description: 'A role within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ addId: true }),
 });
 
 const findRoleCallback = (id: string) => {
@@ -56,8 +55,8 @@ const roleMutations = buildEntityMutations({
   type: RoleType,
   keyName: 'Role',
   typeName: 'role',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ addId: false }),
+  updateFields: getFields({ addId: true }),
   createCallback: createRole,
   updateCallback: updateRole,
   findCallback: findRoleCallback,

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -51,6 +51,7 @@ const roleFields = buildEntityFields({
   findAllCallback: findAllRoles,
   countCallback: countRoles,
 });
+
 const roleMutations = buildEntityMutations({
   type: RoleType,
   keyName: 'Role',

--- a/src/lib/role/graphql.ts
+++ b/src/lib/role/graphql.ts
@@ -2,11 +2,8 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLList,
-  GraphQLInt,
   GraphQLID,
   GraphQLBoolean,
-  GraphQLNonNull,
-  Source,
 } from 'graphql';
 
 import {
@@ -20,6 +17,8 @@ import {
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
+import type { Context } from 'src/types';
+
 const getFields = ({ addId }: { addId: boolean }) => {
   const fields = {
     ...(addId ? { id: { type: GraphQLID } } : {}),
@@ -32,7 +31,7 @@ const getFields = ({ addId }: { addId: boolean }) => {
   return fields;
 };
 
-const RoleType = new GraphQLObjectType({
+const RoleType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'Role',
   description: 'A role within TeachHub',
   fields: getFields({ addId: true }),

--- a/src/lib/subject/graphql.ts
+++ b/src/lib/subject/graphql.ts
@@ -17,12 +17,11 @@ import {
   countSubjects,
 } from './subjectService';
 
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import { buildEntityMutations } from '../../graphql/mutations';
 
 import type { Context } from 'src/types';
 
-const getFields = ({ addId }: { addId: boolean }): GraphqlObjectTypeFields => ({
+const getFields = ({ addId }: { addId: boolean }) => ({
   ...(addId ? { id: { type: GraphQLID } } : {}),
   name: { type: new GraphQLNonNull(GraphQLString) },
   code: { type: new GraphQLNonNull(GraphQLString) },

--- a/src/lib/subject/graphql.ts
+++ b/src/lib/subject/graphql.ts
@@ -5,7 +5,6 @@ import {
   GraphQLString,
   GraphQLNonNull,
   GraphQLID,
-  Source,
   GraphQLBoolean,
 } from 'graphql';
 
@@ -28,7 +27,7 @@ const getFields = ({ addId }: { addId: boolean }) => ({
   active: { type: GraphQLBoolean },
 });
 
-const SubjectType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const SubjectType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'Subject',
   description: 'A subject within TeachHub',
   fields: getFields({ addId: true }),

--- a/src/lib/subject/graphql.ts
+++ b/src/lib/subject/graphql.ts
@@ -3,9 +3,7 @@ import { buildEntityFields } from '../../graphql/fields';
 import {
   GraphQLObjectType,
   GraphQLString,
-  GraphQLList,
   GraphQLNonNull,
-  GraphQLInt,
   GraphQLID,
   Source,
   GraphQLBoolean,
@@ -22,23 +20,19 @@ import {
 import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (addIdd: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
-    name: { type: new GraphQLNonNull(GraphQLString) },
-    code: { type: new GraphQLNonNull(GraphQLString) },
-    active: { type: GraphQLBoolean },
-  };
-  if (addIdd) {
-    fields.id = { type: GraphQLID };
-  }
+import type { Context } from 'src/types';
 
-  return fields;
-};
+const getFields = ({ addId }: { addId: boolean }): GraphqlObjectTypeFields => ({
+  ...(addId ? { id: { type: GraphQLID } } : {}),
+  name: { type: new GraphQLNonNull(GraphQLString) },
+  code: { type: new GraphQLNonNull(GraphQLString) },
+  active: { type: GraphQLBoolean },
+});
 
-const SubjectType = new GraphQLObjectType({
+const SubjectType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'Subject',
   description: 'A subject within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ addId: true }),
 });
 
 const findSubjectCallback = (id: string) => {
@@ -58,8 +52,8 @@ const subjectMutations = buildEntityMutations({
   type: SubjectType,
   keyName: 'Subject',
   typeName: 'subject',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ addId: false }),
+  updateFields: getFields({ addId: true }),
   createCallback: createSubject,
   updateCallback: updateSubject,
   findCallback: findSubjectCallback,

--- a/src/lib/user/graphql.ts
+++ b/src/lib/user/graphql.ts
@@ -7,7 +7,6 @@ import {
   Source,
 } from 'graphql';
 
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import {
   countUsers,
   createUser,
@@ -15,12 +14,15 @@ import {
   findUser,
   updateUser,
 } from './userService';
+
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (addIdd: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
-    ...(addIdd ? { id: { type: GraphQLID } } : {}),
+import type { Context } from 'src/types';
+
+const getFields = ({ addId }: { addId: boolean }) => {
+  const fields = {
+    ...(addId ? { id: { type: GraphQLID } } : {}),
     name: { type: new GraphQLNonNull(GraphQLString) },
     lastName: { type: new GraphQLNonNull(GraphQLString) },
     githubId: { type: new GraphQLNonNull(GraphQLString) },
@@ -32,10 +34,10 @@ const getFields = (addIdd: boolean) => {
   return fields;
 };
 
-const UserType = new GraphQLObjectType({
+const UserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'User',
   description: 'A user within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ addId: true }),
 });
 
 const findUserCallback = (id: string) => {
@@ -55,8 +57,8 @@ const userMutations = buildEntityMutations({
   type: UserType,
   keyName: 'User',
   typeName: 'user',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ addId: false }),
+  updateFields: getFields({ addId: true }),
   createCallback: createUser,
   updateCallback: updateUser,
   findCallback: findUserCallback,

--- a/src/lib/user/graphql.ts
+++ b/src/lib/user/graphql.ts
@@ -4,7 +4,6 @@ import {
   GraphQLNonNull,
   GraphQLBoolean,
   GraphQLID,
-  Source,
 } from 'graphql';
 
 import {
@@ -34,7 +33,7 @@ const getFields = ({ addId }: { addId: boolean }) => {
   return fields;
 };
 
-const UserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const UserType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'User',
   description: 'A user within TeachHub',
   fields: getFields({ addId: true }),

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -4,14 +4,13 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLFieldConfigMap,
-  Source,
 } from 'graphql';
 
 import { updateUser } from './userService';
 
 import type { Context } from '../../types';
 
-export const UserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+export const UserType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'User',
   description: 'A non-admin user within TeachHub',
   fields: {
@@ -24,7 +23,7 @@ export const UserType: GraphQLObjectType<Source, Context> = new GraphQLObjectTyp
   },
 });
 
-export const userMutations: GraphQLFieldConfigMap<Source, Context> = {
+export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
   updateUser: {
     type: UserType,
     description: 'Updates a user',
@@ -48,7 +47,7 @@ export const userMutations: GraphQLFieldConfigMap<Source, Context> = {
   },
 };
 
-export const userFields: GraphQLFieldConfigMap<Source, Context> = {
+export const userFields: GraphQLFieldConfigMap<unknown, Context> = {
   findUser: {
     type: UserType,
     args: { userId: { type: GraphQLID } },

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -3,6 +3,7 @@ import {
   GraphQLString,
   GraphQLNonNull,
   GraphQLObjectType,
+  GraphQLFieldConfigMap,
   Source,
 } from 'graphql';
 
@@ -10,7 +11,7 @@ import { updateUser } from './userService';
 
 import type { Context } from '../../types';
 
-export const UserType = new GraphQLObjectType({
+export const UserType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'User',
   description: 'A non-admin user within TeachHub',
   fields: {
@@ -23,7 +24,7 @@ export const UserType = new GraphQLObjectType({
   },
 });
 
-export const userMutations = {
+export const userMutations: GraphQLFieldConfigMap<Source, Context> = {
   updateUser: {
     type: UserType,
     description: 'Updates a user',
@@ -35,18 +36,19 @@ export const userMutations = {
       githubId: { type: GraphQLString },
       notificationEmail: { type: GraphQLString },
     },
-    resolve: async (_: Source, args: any, ctx: Context) => {
+    resolve: async (_, args, ctx) => {
       const { userId, ...rest } = args;
 
       ctx.logger.info('Executing updateUser mutation with values', args);
 
+      // @ts-expect-error
       const updatedUser = await updateUser(userId, rest);
       return updatedUser;
     },
   },
 };
 
-export const userFields = {
+export const userFields: GraphQLFieldConfigMap<Source, Context> = {
   findUser: {
     type: UserType,
     args: { userId: { type: GraphQLID } },

--- a/src/lib/userRole/graphql.ts
+++ b/src/lib/userRole/graphql.ts
@@ -51,6 +51,7 @@ const userRoleFields = buildEntityFields({
   findAllCallback: findAllUserRoles,
   countCallback: countUserRoles,
 });
+
 const userRoleMutations = buildEntityMutations({
   type: UserRoleType,
   keyName: 'UserRole',

--- a/src/lib/userRole/graphql.ts
+++ b/src/lib/userRole/graphql.ts
@@ -1,11 +1,8 @@
 import {
   GraphQLObjectType,
   GraphQLString,
-  GraphQLList,
-  GraphQLInt,
   GraphQLID,
   GraphQLBoolean,
-  GraphQLNonNull,
   Source,
 } from 'graphql';
 
@@ -17,26 +14,27 @@ import {
   countUserRoles,
 } from './userRoleService';
 
-import { GraphqlObjectTypeFields } from '../../graphql/utils';
 import { buildEntityFields } from '../../graphql/fields';
 import { buildEntityMutations } from '../../graphql/mutations';
 
-const getFields = (addIdd: boolean) => {
-  const fields: GraphqlObjectTypeFields = {
+import type { Context } from 'src/types';
+
+const getFields = ({ addId }: { addId: boolean }) => {
+  const fields = {
+    ...(addId ? { id: { type: GraphQLID } } : {}),
     courseId: { type: GraphQLString },
     roleId: { type: GraphQLString },
     userId: { type: GraphQLString },
     active: { type: GraphQLBoolean },
   };
-  if (addIdd) fields.id = { type: GraphQLID };
 
   return fields;
 };
 
-const UserRoleType = new GraphQLObjectType({
+const UserRoleType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
   name: 'UserRole',
   description: 'A role within TeachHub',
-  fields: getFields(true),
+  fields: getFields({ addId: true }),
 });
 
 const findUserRoleCallback = (id: string) => {
@@ -56,8 +54,8 @@ const userRoleMutations = buildEntityMutations({
   type: UserRoleType,
   keyName: 'UserRole',
   typeName: 'user role',
-  createFields: getFields(false),
-  updateFields: getFields(true),
+  createFields: getFields({ addId: false }),
+  updateFields: getFields({ addId: true }),
   createCallback: createUserRole,
   updateCallback: updateUserRole,
   findCallback: findUserRoleCallback,

--- a/src/lib/userRole/graphql.ts
+++ b/src/lib/userRole/graphql.ts
@@ -1,10 +1,4 @@
-import {
-  GraphQLObjectType,
-  GraphQLString,
-  GraphQLID,
-  GraphQLBoolean,
-  Source,
-} from 'graphql';
+import { GraphQLObjectType, GraphQLString, GraphQLID, GraphQLBoolean } from 'graphql';
 
 import {
   createUserRole,
@@ -31,7 +25,7 @@ const getFields = ({ addId }: { addId: boolean }) => {
   return fields;
 };
 
-const UserRoleType: GraphQLObjectType<Source, Context> = new GraphQLObjectType({
+const UserRoleType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   name: 'UserRole',
   description: 'A role within TeachHub',
   fields: getFields({ addId: true }),

--- a/src/lib/userRole/userRoleService.ts
+++ b/src/lib/userRole/userRoleService.ts
@@ -7,6 +7,7 @@ import {
   findModel,
   updateModel,
 } from '../../sequelize/serviceUtils';
+
 import { IModelFields, ModelAttributes, ModelWhereQuery } from '../../sequelize/types';
 import { Nullable, Optional } from '../../types';
 


### PR DESCRIPTION
Descubrí que los tipos de `graphql` están expuestos junto con las clases de la librería. Así que estoy tipando todo lo que puedo relacionado a eso (cuanto más tipos tengamos en el proyecto mejor).