### PR TITLE
Agrega `UserRoleType` al schema `internal` y IDs globales

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -3,7 +3,6 @@ schema {
   mutation: RootMutationType
 }
 
-"""Courses viewer belongs belongs to"""
 type CourseType {
   active: Boolean!
   id: String!
@@ -46,9 +45,8 @@ type SubjectType {
   name: String
 }
 
-""""""
 type UserRoleType {
-  active: Boolean
+  active: Boolean!
   course: CourseType
   id: String
   role: RoleType
@@ -64,7 +62,6 @@ type UserType {
   lastName: String
   name: String
   notificationEmail: String
-  userRoles: [UserRoleType]
 }
 
 type ViewerType {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -3,20 +3,6 @@ schema {
   mutation: RootMutationType
 }
 
-"""Summary of courses viewer belongs belongs to"""
-type CourseSummaryType {
-  id: String!
-  name: String!
-  period: Int!
-
-  """Role the user has within a course"""
-  role: RoleType!
-
-  """Subject the course belongs to"""
-  subject: SubjectType!
-  year: Int!
-}
-
 """Courses viewer belongs belongs to"""
 type CourseType {
   active: Boolean!
@@ -83,11 +69,10 @@ type UserType {
 
 type ViewerType {
   active: Boolean!
-  courses: [CourseSummaryType]!
   file: String!
 
   """Finds a course for the viewer"""
-  findCourse(id: String!): CourseType @deprecated(reason: "sex")
+  findCourse(id: String!): CourseType
   githubId: String!
   id: String!
   lastName: String!

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -44,7 +44,7 @@ type RoleType {
 """Root mutation"""
 type RootMutationType {
   """Updates a user"""
-  updateUser(file: String, githubId: String, lastName: String, name: String, notificationEmail: String, userId: ID!): UserType
+  updateUser(file: String, githubId: String, lastName: String, name: String, notificationEmail: String, userId: String!): UserType
 }
 
 """Root query"""
@@ -87,7 +87,7 @@ type ViewerType {
   file: String!
 
   """Finds a course for the viewer"""
-  findCourse(id: String!): CourseType
+  findCourse(id: String!): CourseType @deprecated(reason: "sex")
   githubId: String!
   id: String!
   lastName: String!

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -25,14 +25,11 @@ type CourseType {
   organization: String!
   period: Int!
 
-  """Role the user has within a course"""
-  role: RoleType!
-
   """Subject the course belongs to"""
   subject: SubjectType!
 
-  """Users in course"""
-  users: [UserType]!
+  """User roles within a course"""
+  userRoles: [UserRoleType]
   year: Int!
 }
 
@@ -63,6 +60,15 @@ type SubjectType {
   name: String
 }
 
+""""""
+type UserRoleType {
+  active: Boolean
+  course: CourseType
+  id: String
+  role: RoleType
+  user: UserType
+}
+
 """A non-admin user within TeachHub"""
 type UserType {
   active: Boolean
@@ -72,6 +78,7 @@ type UserType {
   lastName: String
   name: String
   notificationEmail: String
+  userRoles: [UserRoleType]
 }
 
 type ViewerType {
@@ -86,4 +93,7 @@ type ViewerType {
   lastName: String!
   name: String!
   notificationEmail: String!
+
+  """User user roles"""
+  userRoles: [UserRoleType]
 }

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -13,7 +13,7 @@ type CourseSummaryType {
   role: RoleType!
 
   """Subject the course belongs to"""
-  subject: Subject!
+  subject: SubjectType!
   year: Int!
 }
 
@@ -29,7 +29,7 @@ type CourseType {
   role: RoleType!
 
   """Subject the course belongs to"""
-  subject: Subject!
+  subject: SubjectType!
 
   """Users in course"""
   users: [UserType]!
@@ -38,7 +38,7 @@ type CourseType {
 
 type RoleType {
   active: Boolean
-  id: Int
+  id: String
   name: String
   parent: RoleType
   permissions: [String]
@@ -56,12 +56,11 @@ type RootQueryType {
   viewer: ViewerType
 }
 
-"""A subject within TeachHub"""
-type Subject {
+type SubjectType {
   active: Boolean
-  code: String!
-  id: ID
-  name: String!
+  code: String
+  id: String
+  name: String
 }
 
 """A non-admin user within TeachHub"""
@@ -69,7 +68,7 @@ type UserType {
   active: Boolean
   file: String
   githubId: String
-  id: ID
+  id: String
   lastName: String
   name: String
   notificationEmail: String
@@ -81,7 +80,7 @@ type ViewerType {
   file: String!
 
   """Finds a course for the viewer"""
-  findCourse(id: Int!): CourseType
+  findCourse(id: String!): CourseType
   githubId: String!
   id: String!
   lastName: String!

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/lodash": "^4.14.191",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "express-graphql": "^0.12.0",
         "graphql": "^15.8.0",
+        "lodash": "^4.17.21",
         "pg": "^8.8.0",
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.25.3",
@@ -100,6 +102,11 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -2454,6 +2461,11 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "@types/mime": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
   "homepage": "https://github.com/teach-hub/core-service#readme",
   "description": "",
   "dependencies": {
+    "@types/lodash": "^4.14.191",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "express-graphql": "^0.12.0",
     "graphql": "^15.8.0",
+    "lodash": "^4.17.21",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.25.3",

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -14,8 +14,10 @@ import { findAllUserRoles, findUserRoleInCourse } from '../lib/userRole/userRole
 import { findCourse } from '../lib/course/courseService';
 
 import { userMutations } from '../lib/user/internalGraphql';
-import { CourseType, CourseSummaryType } from '../lib/course/internalGraphql';
-import { UserRoleType } from '../lib/userRole/internalGraphql';
+import { CourseType } from '../lib/course/internalGraphql';
+import { UserType } from '../lib/user/internalGraphql';
+import { RoleType } from '../lib/role/internalGraphql';
+import { buildUserRoleType } from '../lib/userRole/internalGraphql';
 
 import { toGlobalId, fromGlobalId } from './utils';
 
@@ -46,6 +48,12 @@ const getViewer = async (ctx: Context): Promise<UserFields> => {
   };
 };
 
+const UserRoleType = buildUserRoleType({
+  roleType: RoleType,
+  userType: UserType,
+  courseType: CourseType,
+});
+
 const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType({
   name: 'ViewerType',
   fields: {
@@ -71,9 +79,7 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
       },
     },
     findCourse: {
-      args: {
-        id: { type: new GraphQLNonNull(GraphQLString) },
-      },
+      args: { id: { type: new GraphQLNonNull(GraphQLString) } },
       description: 'Finds a course for the viewer',
       type: CourseType,
       resolve: async (viewer, args, { logger }) => {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -44,7 +44,15 @@ const getViewer = async (ctx: Context): Promise<UserFields> => {
 const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType({
   name: 'ViewerType',
   fields: {
-    id: { type: new GraphQLNonNull(GraphQLString) },
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: s => {
+        return toGlobalId({
+          entityName: 'viewer',
+          dbId: String(s.id) as string,
+        });
+      },
+    },
     name: { type: new GraphQLNonNull(GraphQLString) },
     lastName: { type: new GraphQLNonNull(GraphQLString) },
     file: { type: new GraphQLNonNull(GraphQLString) },
@@ -52,7 +60,9 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
     githubId: { type: new GraphQLNonNull(GraphQLString) },
     notificationEmail: { type: new GraphQLNonNull(GraphQLString) },
     findCourse: {
-      args: { id: { type: new GraphQLNonNull(GraphQLInt) } },
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLString) },
+      },
       description: 'Finds a course for the viewer',
       type: CourseType,
       resolve: async (viewer, args, { logger }) => {
@@ -68,14 +78,7 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
 
         return {
           ...course,
-          id: toGlobalId({
-            entityName: 'course',
-            dbId: String(course.id) as string,
-          }),
-          roleId: toGlobalId({
-            entityName: 'role',
-            dbId: String(userRole.roleId),
-          }),
+          roleId: userRole.roleId,
         };
       },
     },
@@ -91,14 +94,7 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
 
             return {
               ...course,
-              id: toGlobalId({
-                entityName: 'course',
-                dbId: String(course.id) as string,
-              }),
-              roleId: toGlobalId({
-                entityName: 'role',
-                dbId: String(userRole.roleId),
-              }),
+              roleId: userRole.roleId,
             };
           })
         );
@@ -117,13 +113,7 @@ const Query: GraphQLObjectType<null, Context> = new GraphQLObjectType({
       resolve: async (_source, _args, ctx) => {
         const viewer = await getViewer(ctx);
 
-        return {
-          ...viewer,
-          id: toGlobalId({
-            dbId: String(viewer.id),
-            entityName: 'viewer',
-          }),
-        };
+        return viewer;
       },
     },
   },

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -7,4 +7,16 @@ const RAArgs = {
   sortOrder: { type: GraphQLString },
 };
 
+type GlobalId = string;
+type EntityPayload = { entityName: string; dbId: string };
+
+export const toGlobalId = ({ dbId, entityName }: EntityPayload): GlobalId => {
+  return btoa(`${entityName}:${dbId}`);
+};
+
+export const fromGlobalId = (globalId: GlobalId): EntityPayload => {
+  const decoded = atob(globalId).split(':');
+  return { entityName: decoded[0], dbId: decoded[1] };
+};
+
 export { RAArgs };

--- a/src/lib/course/internalGraphql.ts
+++ b/src/lib/course/internalGraphql.ts
@@ -9,71 +9,56 @@ import {
 
 import { RoleType } from '../role/internalGraphql';
 import { SubjectType } from '../subject/internalGraphql';
-import { UserType } from '../user/internalGraphql';
 
 import { findSubject } from '../subject/subjectService';
 import { findRole } from '../role/roleService';
-import { findUsersInCourse } from '../user/userService';
+import { findAllUserRoles } from '../userRole/userRoleService';
+
+import { toGlobalId } from '../../graphql/utils';
 
 import type { Context } from 'src/types';
 import type { CourseFields } from './courseService';
-
-import { toGlobalId, fromGlobalId } from '../../graphql/utils';
 
 export const CourseType: GraphQLObjectType<CourseFields, Context> = new GraphQLObjectType(
   {
     name: 'CourseType',
     description: 'Courses viewer belongs belongs to',
-    fields: {
-      id: {
-        type: new GraphQLNonNull(GraphQLString),
-        resolve: s => {
-          return toGlobalId({
-            entityName: 'course',
-            dbId: String(s.id) as string,
-          });
-        },
-      },
-      name: { type: new GraphQLNonNull(GraphQLString) },
-      organization: { type: new GraphQLNonNull(GraphQLString) },
-      period: { type: new GraphQLNonNull(GraphQLInt) },
-      year: { type: new GraphQLNonNull(GraphQLInt) },
-      active: { type: new GraphQLNonNull(GraphQLBoolean) },
-      role: {
-        type: new GraphQLNonNull(RoleType),
-        description: 'Role the user has within a course',
-        resolve: async (userCourse, _, ctx) => {
-          const { roleId } = userCourse;
+    fields: () => {
+      const UserRoleType = require('../userRole/internalGraphql').UserRoleType;
 
-          ctx.logger.info('Finding role with id', { roleId });
-
-          return findRole({ roleId });
+      return {
+        id: {
+          type: new GraphQLNonNull(GraphQLString),
+          resolve: s => {
+            return toGlobalId({
+              entityName: 'course',
+              dbId: String(s.id) as string,
+            });
+          },
         },
-      },
-      subject: {
-        type: new GraphQLNonNull(SubjectType),
-        description: 'Subject the course belongs to',
-        resolve: async ({ subjectId }) => {
-          const subject = subjectId
-            ? await findSubject({ subjectId: String(subjectId) })
-            : null;
-          return subject;
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        organization: { type: new GraphQLNonNull(GraphQLString) },
+        period: { type: new GraphQLNonNull(GraphQLInt) },
+        year: { type: new GraphQLNonNull(GraphQLInt) },
+        active: { type: new GraphQLNonNull(GraphQLBoolean) },
+        userRoles: {
+          type: new GraphQLList(UserRoleType),
+          description: 'User roles within a course',
+          resolve: course => {
+            return findAllUserRoles({ forCourseId: course.id });
+          },
         },
-      },
-      users: {
-        type: new GraphQLNonNull(new GraphQLList(UserType)),
-        description: 'Users in course',
-        resolve: async (course, _, ctx) => {
-          const { logger } = ctx;
-
-          logger.info(`Looking for users within course ${course.id}`);
-
-          const users = course.id
-            ? await findUsersInCourse({ courseId: course.id })
-            : null;
-          return users;
+        subject: {
+          type: new GraphQLNonNull(SubjectType),
+          description: 'Subject the course belongs to',
+          resolve: async ({ subjectId }) => {
+            const subject = subjectId
+              ? await findSubject({ subjectId: String(subjectId) })
+              : null;
+            return subject;
+          },
         },
-      },
+      };
     },
   }
 );

--- a/src/lib/course/internalGraphql.ts
+++ b/src/lib/course/internalGraphql.ts
@@ -18,6 +18,8 @@ import { findUsersInCourse } from '../user/userService';
 import type { Context } from 'src/types';
 import type { CourseFields } from './courseService';
 
+import { toGlobalId, fromGlobalId } from 'src/graphql/utils';
+
 export const CourseType: GraphQLObjectType<CourseFields, Context> = new GraphQLObjectType(
   {
     name: 'CourseType',
@@ -33,10 +35,19 @@ export const CourseType: GraphQLObjectType<CourseFields, Context> = new GraphQLO
         type: new GraphQLNonNull(RoleType),
         description: 'Role the user has within a course',
         resolve: async (userCourse, _) => {
-          const { roleId } = userCourse;
+          const { roleId: roleIdEncoded } = userCourse;
+
+          const { dbId: roleId } = fromGlobalId(roleIdEncoded);
 
           const role = await findRole({ roleId });
-          return role;
+
+          return {
+            ...role,
+            id: toGlobalId({
+              dbId: String(role.id),
+              entityName: 'role',
+            }),
+          };
         },
       },
       subject: {

--- a/src/lib/role/internalGraphql.ts
+++ b/src/lib/role/internalGraphql.ts
@@ -1,19 +1,23 @@
-import {
-  GraphQLInt,
-  GraphQLString,
-  GraphQLBoolean,
-  GraphQLList,
-  GraphQLObjectType,
-} from 'graphql';
+import { GraphQLString, GraphQLBoolean, GraphQLList, GraphQLObjectType } from 'graphql';
 
 import type { Context } from 'src/types';
 
 import { findRole } from './roleService';
 
+import { toGlobalId } from '../../graphql/utils';
+
 export const RoleType: GraphQLObjectType<any, Context> = new GraphQLObjectType({
   name: 'RoleType',
   fields: () => ({
-    id: { type: GraphQLInt },
+    id: {
+      type: GraphQLString,
+      resolve: role => {
+        return toGlobalId({
+          entityName: 'role',
+          dbId: String(role.id),
+        });
+      },
+    },
     name: { type: GraphQLString },
     permissions: { type: new GraphQLList(GraphQLString) },
     active: { type: GraphQLBoolean },
@@ -22,6 +26,8 @@ export const RoleType: GraphQLObjectType<any, Context> = new GraphQLObjectType({
       resolve: async (source, _, context) => {
         const { logger } = context;
         const { id, parentRoleId } = source;
+
+        if (!parentRoleId) return null;
 
         logger.info(`Resolving parent role for role ${id}`);
 

--- a/src/lib/subject/internalGraphql.ts
+++ b/src/lib/subject/internalGraphql.ts
@@ -1,0 +1,20 @@
+import { GraphQLString, GraphQLBoolean, GraphQLObjectType } from 'graphql';
+
+import { toGlobalId } from '../../graphql/utils';
+
+export const SubjectType = new GraphQLObjectType({
+  name: 'SubjectType',
+  fields: {
+    id: {
+      type: GraphQLString,
+      resolve: s =>
+        toGlobalId({
+          entityName: 'subject',
+          dbId: String(s.id) as string,
+        }),
+    },
+    name: { type: GraphQLString },
+    code: { type: GraphQLString },
+    active: { type: GraphQLBoolean },
+  },
+});

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -3,34 +3,46 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLNonNull,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLFieldConfigMap,
 } from 'graphql';
 
 import { UserFields, updateUser } from './userService';
+import { findAllUserRoles } from '../userRole/userRoleService';
 
-import { toGlobalId, fromGlobalId } from '../../graphql/utils';
+import { toGlobalId } from '../../graphql/utils';
 
 import type { Context } from '../../types';
 
 export const UserType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType({
   name: 'UserType',
   description: 'A non-admin user within TeachHub',
-  fields: {
-    id: {
-      type: GraphQLString,
-      resolve: s =>
-        toGlobalId({
-          entityName: 'user',
-          dbId: String(s.id) as string,
-        }),
-    },
-    name: { type: GraphQLString },
-    active: { type: GraphQLBoolean },
-    lastName: { type: GraphQLString },
-    notificationEmail: { type: GraphQLString },
-    file: { type: GraphQLString },
-    githubId: { type: GraphQLString },
+  fields: () => {
+    const UserRoleType = require('../userRole/internalGraphql').UserRoleType;
+
+    return {
+      id: {
+        type: GraphQLString,
+        resolve: s =>
+          toGlobalId({
+            entityName: 'user',
+            dbId: String(s.id) as string,
+          }),
+      },
+      name: { type: GraphQLString },
+      active: { type: GraphQLBoolean },
+      lastName: { type: GraphQLString },
+      notificationEmail: { type: GraphQLString },
+      file: { type: GraphQLString },
+      githubId: { type: GraphQLString },
+      userRoles: {
+        type: new GraphQLList(UserRoleType),
+        resolve: user => {
+          return findAllUserRoles({ forUserId: user.id });
+        },
+      },
+    };
   },
 });
 

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -11,7 +11,7 @@ import {
 import { UserFields, updateUser } from './userService';
 import { findAllUserRoles } from '../userRole/userRoleService';
 
-import { toGlobalId } from '../../graphql/utils';
+import { toGlobalId, fromGlobalId } from '../../graphql/utils';
 
 import type { Context } from '../../types';
 
@@ -51,10 +51,7 @@ export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
     type: UserType,
     description: 'Updates a user',
     args: {
-      userId: {
-        // FIXME;
-        type: new GraphQLNonNull(GraphQLID),
-      },
+      userId: { type: new GraphQLNonNull(GraphQLString) },
       name: { type: GraphQLString },
       lastName: { type: GraphQLString },
       file: { type: GraphQLString },
@@ -63,11 +60,12 @@ export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
     },
     resolve: async (_, args, ctx) => {
       const { userId, ...rest } = args;
+      const { dbId } = fromGlobalId(userId);
 
       ctx.logger.info('Executing updateUser mutation with values', args);
 
       // @ts-expect-error
-      const updatedUser = await updateUser(userId, rest);
+      const updatedUser = await updateUser(dbId, rest);
       return updatedUser;
     },
   },

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -9,13 +9,22 @@ import {
 
 import { UserFields, updateUser } from './userService';
 
+import { toGlobalId, fromGlobalId } from '../../graphql/utils';
+
 import type { Context } from '../../types';
 
 export const UserType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType({
   name: 'UserType',
   description: 'A non-admin user within TeachHub',
   fields: {
-    id: { type: GraphQLID },
+    id: {
+      type: GraphQLString,
+      resolve: s =>
+        toGlobalId({
+          entityName: 'user',
+          dbId: String(s.id) as string,
+        }),
+    },
     name: { type: GraphQLString },
     active: { type: GraphQLBoolean },
     lastName: { type: GraphQLString },
@@ -30,7 +39,10 @@ export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
     type: UserType,
     description: 'Updates a user',
     args: {
-      userId: { type: new GraphQLNonNull(GraphQLID) },
+      userId: {
+        // FIXME;
+        type: new GraphQLNonNull(GraphQLID),
+      },
       name: { type: GraphQLString },
       lastName: { type: GraphQLString },
       file: { type: GraphQLString },

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -1,15 +1,12 @@
 import {
-  GraphQLID,
   GraphQLString,
   GraphQLBoolean,
   GraphQLNonNull,
-  GraphQLList,
   GraphQLObjectType,
   GraphQLFieldConfigMap,
 } from 'graphql';
 
 import { UserFields, updateUser } from './userService';
-import { findAllUserRoles } from '../userRole/userRoleService';
 
 import { toGlobalId, fromGlobalId } from '../../graphql/utils';
 
@@ -18,31 +15,21 @@ import type { Context } from '../../types';
 export const UserType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType({
   name: 'UserType',
   description: 'A non-admin user within TeachHub',
-  fields: () => {
-    const UserRoleType = require('../userRole/internalGraphql').UserRoleType;
-
-    return {
-      id: {
-        type: GraphQLString,
-        resolve: s =>
-          toGlobalId({
-            entityName: 'user',
-            dbId: String(s.id) as string,
-          }),
-      },
-      name: { type: GraphQLString },
-      active: { type: GraphQLBoolean },
-      lastName: { type: GraphQLString },
-      notificationEmail: { type: GraphQLString },
-      file: { type: GraphQLString },
-      githubId: { type: GraphQLString },
-      userRoles: {
-        type: new GraphQLList(UserRoleType),
-        resolve: user => {
-          return findAllUserRoles({ forUserId: user.id });
-        },
-      },
-    };
+  fields: {
+    id: {
+      type: GraphQLString,
+      resolve: s =>
+        toGlobalId({
+          entityName: 'user',
+          dbId: String(s.id) as string,
+        }),
+    },
+    name: { type: GraphQLString },
+    active: { type: GraphQLBoolean },
+    lastName: { type: GraphQLString },
+    notificationEmail: { type: GraphQLString },
+    file: { type: GraphQLString },
+    githubId: { type: GraphQLString },
   },
 });
 

--- a/src/lib/userRole/internalGraphql.ts
+++ b/src/lib/userRole/internalGraphql.ts
@@ -1,0 +1,45 @@
+import { GraphQLObjectType, GraphQLString, GraphQLBoolean } from 'graphql';
+
+import { findRole } from '../role/roleService';
+import { findCourse } from '../course/courseService';
+import { findUser } from '../user/userService';
+
+import { UserType } from '../user/internalGraphql';
+import { RoleType } from '../role/internalGraphql';
+import { CourseType } from '../course/internalGraphql';
+
+import { toGlobalId } from '../../graphql/utils';
+
+export const UserRoleType = new GraphQLObjectType({
+  name: 'UserRoleType',
+  description: '',
+  fields: {
+    id: {
+      type: GraphQLString,
+      resolve: s =>
+        toGlobalId({
+          entityName: 'userRole',
+          dbId: String(s.id) as string,
+        }),
+    },
+    active: { type: GraphQLBoolean },
+    user: {
+      type: UserType,
+      resolve: userRole => {
+        return findUser({ userId: String(userRole.userId) });
+      },
+    },
+    role: {
+      type: RoleType,
+      resolve: userRole => {
+        return findRole({ roleId: String(userRole.roleId) });
+      },
+    },
+    course: {
+      type: CourseType,
+      resolve: userRole => {
+        return findCourse({ courseId: String(userRole.courseId) });
+      },
+    },
+  },
+});

--- a/src/lib/userRole/internalGraphql.ts
+++ b/src/lib/userRole/internalGraphql.ts
@@ -1,45 +1,56 @@
-import { GraphQLObjectType, GraphQLString, GraphQLBoolean } from 'graphql';
+import {
+  GraphQLOutputType,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLNonNull,
+} from 'graphql';
 
 import { findRole } from '../role/roleService';
 import { findCourse } from '../course/courseService';
 import { findUser } from '../user/userService';
 
-import { UserType } from '../user/internalGraphql';
-import { RoleType } from '../role/internalGraphql';
-import { CourseType } from '../course/internalGraphql';
-
 import { toGlobalId } from '../../graphql/utils';
 
-export const UserRoleType = new GraphQLObjectType({
-  name: 'UserRoleType',
-  description: '',
-  fields: {
-    id: {
-      type: GraphQLString,
-      resolve: s =>
-        toGlobalId({
-          entityName: 'userRole',
-          dbId: String(s.id) as string,
-        }),
-    },
-    active: { type: GraphQLBoolean },
-    user: {
-      type: UserType,
-      resolve: userRole => {
-        return findUser({ userId: String(userRole.userId) });
-      },
-    },
-    role: {
-      type: RoleType,
-      resolve: userRole => {
-        return findRole({ roleId: String(userRole.roleId) });
-      },
-    },
-    course: {
-      type: CourseType,
-      resolve: userRole => {
-        return findCourse({ courseId: String(userRole.courseId) });
-      },
-    },
-  },
-});
+let _instance: GraphQLOutputType | null = null;
+
+export const buildUserRoleType = ({
+  roleType,
+  userType,
+  courseType,
+}: {
+  roleType: GraphQLOutputType;
+  userType: GraphQLOutputType;
+  courseType: GraphQLOutputType;
+}) => {
+  _instance = _instance
+    ? _instance
+    : new GraphQLObjectType({
+        name: 'UserRoleType',
+        fields: {
+          id: {
+            type: GraphQLString,
+            resolve: s =>
+              toGlobalId({
+                entityName: 'userRole',
+                dbId: String(s.id) as string,
+              }),
+          },
+          active: { type: new GraphQLNonNull(GraphQLBoolean) },
+          user: {
+            type: userType,
+            resolve: userRole => findUser({ userId: String(userRole.userId) }),
+          },
+          role: {
+            type: roleType,
+            resolve: userRole => findRole({ roleId: String(userRole.roleId) }),
+          },
+          course: {
+            type: courseType,
+            resolve: userRole => findCourse({ courseId: String(userRole.courseId) }),
+          },
+        },
+      });
+
+  return _instance;
+};


### PR DESCRIPTION
Este PR extiende el schema actual con nuevas relaciones pero además agrega IDs globales.

¿Por qué IDs globales?

Relay tiene la store fetcheando objetos y los identifica por los IDs así que ahí pueden colisionar el ID = 1 de el usuario con el ID = 1 de la materia. La forma más fácil de hacer IDs globales es 

`<id global> = base64(<nombre entidad> + <id original>)` 

---

Agregué al schema la entidad `UserRole` copiando un poco el esquema que tenemos en la base de datos ¿por qué? porque tenemos los siguientes casos

"Quiero todos los roles que tiene un usuario (es decir la cátedra y el rol)"

Pero para saber el rol dentro de un curso tengo que saber de que usuario estoy hablando. 

```graphql
{ 
   ...
   user {
     courses { 
       role { 
        ...
      }
    }
  }
}
```

"Quiero usuarios junto con los roles dentro de una cátedra"

Pero ya para saber que rol tiene el usuario tengo que saber de qué cátedra estoy hablando.

```graphql
{ 
     ....
     course { 
       users { 
         role {
          ...
        }
      }
    }
  }
}
```

Con esto agregamos el userRole y pedimos

```graphql
{ 
     ....
     course { 
       userRoles {
         user {
         ...
         }
         role {
          ...
         }
      }
    }
  }
}
```
