### PR TITLE
[No ticket] Usar sustantivos para los finders

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -18,11 +18,11 @@ type AssignmentType {
 type CourseType {
   active: Boolean!
 
+  """Finds an assignment for a specific course"""
+  assignment(id: String!): AssignmentType
+
   """Active assignments within the course"""
   assignments: [AssignmentType!]!
-
-  """Finds an assignment for a specific course"""
-  findAssignment(id: String!): AssignmentType
   id: String!
   name: String!
   organization: String
@@ -96,11 +96,11 @@ type RootMutationType {
 
 """Root query"""
 type RootQueryType {
+  """Finds an assignment by id"""
+  assignment(id: String!): AssignmentType
+
   """Logged in user"""
   availableRoles: [RoleType!]!
-
-  """Finds an assignment by id"""
-  findAssignment(id: String!): AssignmentType
 
   """Logged in user"""
   viewer: ViewerType
@@ -146,10 +146,10 @@ type ViewerType {
 
   """Get available github organizations for a user"""
   availableOrganizations: ViewerOrganizations
-  file: String!
 
   """Finds a course for the viewer"""
-  findCourse(id: String!): CourseType
+  course(id: String!): CourseType
+  file: String!
   githubId: String!
   id: String!
   lastName: String!

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -68,7 +68,7 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
         return response;
       },
     },
-    findCourse: {
+    course: {
       args: { id: { type: new GraphQLNonNull(GraphQLString) } },
       description: 'Finds a course for the viewer',
       type: CourseType,
@@ -122,7 +122,7 @@ const Query: GraphQLObjectType<null, Context> = new GraphQLObjectType({
         return roles;
       },
     },
-    findAssignment: {
+    assignment: {
       args: { id: { type: new GraphQLNonNull(GraphQLString) } },
       description: 'Finds an assignment by id',
       type: AssignmentType,

--- a/src/lib/course/internalGraphql.ts
+++ b/src/lib/course/internalGraphql.ts
@@ -133,7 +133,7 @@ export const CourseType: GraphQLObjectType<CourseFields, Context> = new GraphQLO
               : [];
           },
         },
-        findAssignment: {
+        assignment: {
           args: { id: { type: new GraphQLNonNull(GraphQLString) } },
           description: 'Finds an assignment for a specific course',
           type: AssignmentType,


### PR DESCRIPTION
Estuve viendo algunas buenas prácticas de trabajar con GraphQL

- Nombres de finders deberían ser los mismos sutantivos
 https://www.apollographql.com/blog/graphql/filtering/how-to-search-and-filter-results-with-graphql/
 
 - Usar ID para representar los IDs (ja), esto se sigue serializando como `string` pero no nos ata al tipo
 

Cambios en frontend https://github.com/teach-hub/frontoffice/pull/26