### PR TITLE
Update graphql for user profile changes

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -312,6 +312,7 @@ type UserType {
   active: Boolean!
   file: String!
   githubId: String!
+  githubUserName: String!
   id: ID!
   lastName: String!
   name: String!
@@ -333,6 +334,7 @@ type ViewerType {
   course(id: ID!): CourseType
   file: String!
   githubId: String!
+  githubUserName: String!
   id: String!
   lastName: String!
   name: String!

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -244,8 +244,8 @@ type RootMutationType {
   """Updates a review grade and / or revision requested status"""
   updateReview(courseId: ID!, grade: Int, id: ID!, revisionRequested: Boolean!): InternalReviewType!
 
-  """Updates a user"""
-  updateUser(file: String, githubId: String, lastName: String, name: String, notificationEmail: String, userId: ID!): UserType
+  """Updates viewer user"""
+  updateViewerUser(file: String, githubId: String, lastName: String, name: String, notificationEmail: String): UserType
 
   """Marks an invite as used returning the course id"""
   useInvite(inviteId: ID!): UseInviteResponse!

--- a/src/graphql/rules.ts
+++ b/src/graphql/rules.ts
@@ -1,4 +1,4 @@
-import { allow, deny, or, rule, shield } from 'graphql-shield';
+import { allow, or, rule, shield } from 'graphql-shield';
 
 import { getViewer } from '../lib/user/internalGraphql';
 
@@ -161,11 +161,7 @@ export default shield<null, Context, unknown>(
     CreateSubmissionResultType: allow,
     RootMutationType: {
       registerUser: allow,
-      /**
-       * Todavia no tenemos caso de uso para
-       * esta mutation.
-       */
-      updateUser: deny,
+      updateViewerUser: allow, // Allow each viewer to update its user
       login: allow,
       logout: allow,
       useInvite: allow,

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -28,7 +28,10 @@ import { fromGlobalId, toGlobalId } from './utils';
 
 import { getToken } from '../utils/request';
 
-import { getGithubUserOrganizationNames } from '../github/githubUser';
+import {
+  getGithubUsernameFromGithubId,
+  getGithubUserOrganizationNames,
+} from '../github/githubUser';
 import { listOpenPRs } from '../github/pullrequests';
 import { initOctokit } from '../github/config';
 
@@ -167,6 +170,16 @@ const ViewerType: GraphQLObjectType<UserFields, Context> = new GraphQLObjectType
         return {
           names: await getGithubUserOrganizationNames(token),
         };
+      },
+    },
+    githubUserName: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: async (viewer, _, ctx) => {
+        const token = getToken(ctx);
+        if (!token) throw new Error('Token required');
+        if (!viewer.githubId) throw new Error('User missing githubId');
+
+        return getGithubUsernameFromGithubId(initOctokit(token), viewer.githubId);
       },
     },
   },

--- a/src/lib/role/roleService.ts
+++ b/src/lib/role/roleService.ts
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
 
 import { OrderingOptions } from '../../utils';
-import { Permission, ALL_PERMISSIONS } from '../../consts';
+import { ALL_PERMISSIONS, Permission } from '../../consts';
 import { Nullable, Optional } from '../../types';
 import {
   countModels,

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -1,7 +1,7 @@
 import {
-  GraphQLID,
   GraphQLBoolean,
   GraphQLFieldConfigMap,
+  GraphQLID,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
@@ -15,7 +15,7 @@ import {
   UserFields,
 } from './userService';
 
-import { fromGlobalId, toGlobalId } from '../../graphql/utils';
+import { toGlobalId } from '../../graphql/utils';
 
 import type { Context } from '../../types';
 import { createRegisteredUserTokenFromJwt, isRegisterToken } from '../../tokens/jwt';
@@ -112,11 +112,10 @@ export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
       };
     },
   },
-  updateUser: {
+  updateViewerUser: {
     type: UserType,
-    description: 'Updates a user',
+    description: 'Updates viewer user',
     args: {
-      userId: { type: new GraphQLNonNull(GraphQLID) },
       name: { type: GraphQLString },
       lastName: { type: GraphQLString },
       file: { type: GraphQLString },
@@ -124,13 +123,13 @@ export const userMutations: GraphQLFieldConfigMap<unknown, Context> = {
       notificationEmail: { type: GraphQLString },
     },
     resolve: async (_, args, ctx) => {
-      const { userId, ...rest } = args;
-      const { dbId } = fromGlobalId(userId);
+      const viewer = await getViewer(ctx);
+      const { ...rest } = args;
 
       ctx.logger.info('Executing updateUser mutation with values', args);
 
       // @ts-expect-error. FIXME
-      return updateUser(dbId, rest);
+      return updateUser(viewer.id, rest);
     },
   },
 };


### PR DESCRIPTION
- Agrega github username como prop del viewer y el user
- Cambia la mutation de update user para que que sea update user del viewer, y se cambia la rule que estaba en deny a allow, dado que solo vas a poder actualizar tu user