### PR TITLE
[No ticket] Dejar de usar `string` para ids de la base de datos

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -28,9 +28,6 @@ type AssignmentType {
   startDate: String
   submissions: [SubmissionType!]!
   title: String
-
-  """Whether the viewer has already made a submission or not."""
-  viewerAlreadyMadeSubmission: Boolean!
   viewerReviewer: ReviewerType
   viewerSubmission: SubmissionType
 }

--- a/src/github/pullrequests.ts
+++ b/src/github/pullrequests.ts
@@ -16,7 +16,7 @@ type PullRequest = {
 
 export const listOpenPRs = async (
   viewer: UserFields,
-  courseId: string,
+  courseId: number,
   octoClient: Octokit
 ): Promise<PullRequest[]> => {
   const { organization } = await findCourse({ courseId });
@@ -27,7 +27,7 @@ export const listOpenPRs = async (
   }
 
   const courseRepos = await findAllRepositories({
-    forUserId: String(viewer.id),
+    forUserId: viewer.id,
     forCourseId: courseId,
   });
 

--- a/src/graphql/fields.ts
+++ b/src/graphql/fields.ts
@@ -15,7 +15,7 @@ import type { Context } from 'src/types';
 
 const buildFindTypeObject = <T>(
   type: GraphQLOutputType,
-  findCallback: (id: string) => Promise<T>
+  findCallback: (id: number) => Promise<T>
 ): GraphQLFieldConfig<unknown, Context> => {
   return {
     type,
@@ -68,7 +68,7 @@ type FieldParams<T> = {
   type: GraphQLOutputType;
   keyName: string;
   countCallback: () => Promise<number>;
-  findCallback: (id: string) => Promise<T>;
+  findCallback: (id: number) => Promise<T>;
   findAllCallback: (args: OrderingOptions) => Promise<T[]>;
 };
 

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -16,11 +16,11 @@ type CreateMutationOptions<T> = {
 
 type UpdateMutationOptions<T> = {
   args: GraphQLFieldConfigArgumentMap;
-  callback: (id: string, args: T) => Promise<T>;
+  callback: (id: number, args: T) => Promise<T>;
 };
 
 type DeleteOptions<T> = {
-  findCallback: (id: string) => Promise<T>;
+  findCallback: (id: number) => Promise<T>;
 };
 
 type MutationsParams<T> = {

--- a/src/graphql/rules.ts
+++ b/src/graphql/rules.ts
@@ -56,7 +56,11 @@ async function viewerIsCourseTeacher(
     forUserId: ctx.viewerUserId,
   });
 
-  const viewerRole = await findRole({ roleId: String(viewerUserRole.roleId) });
+  if (!viewerUserRole.roleId) {
+    return false;
+  }
+
+  const viewerRole = await findRole({ roleId: viewerUserRole.roleId });
 
   if (!viewerRole) {
     return false;
@@ -94,11 +98,11 @@ async function userHasPermissionInCourse({
     forUserId: user.id,
   });
 
-  if (!userUserRole) {
+  if (!userUserRole || !userUserRole.roleId) {
     return false;
   }
 
-  const userRole = await findRole({ roleId: String(userUserRole.roleId) });
+  const userRole = await findRole({ roleId: userUserRole.roleId });
 
   const { permissions } = await consolidateRoles(userRole);
   return (permissions ?? []).includes(permission);
@@ -110,7 +114,7 @@ const viewerHasPermissionInCourse = (permission: Permission) =>
 
     const [viewer, course] = await Promise.all([
       findUser(context.viewerUserId),
-      findCourse({ courseId: String(courseId) }),
+      findCourse({ courseId }),
     ]);
 
     if (!course || !viewer) {

--- a/src/graphql/rules.ts
+++ b/src/graphql/rules.ts
@@ -8,7 +8,7 @@ import { findCourse } from '../lib/course/courseService';
 import type { UserRoleFields } from '../lib/userRole/userRoleService';
 import { findAllUserRoles } from '../lib/userRole/userRoleService';
 
-import { fromGlobalId } from './utils';
+import { fromGlobalIdAsNumber } from './utils';
 import { findUser, UserFields } from '../lib/user/userService';
 
 import { Permission } from '../consts';
@@ -106,11 +106,11 @@ async function userHasPermissionInCourse({
 
 const viewerHasPermissionInCourse = (permission: Permission) =>
   buildRule(async (_, args, context) => {
-    const { dbId: courseId } = fromGlobalId(args.courseId);
+    const courseId = fromGlobalIdAsNumber(args.courseId);
 
     const [viewer, course] = await Promise.all([
       findUser(context.viewerUserId),
-      findCourse({ courseId }),
+      findCourse({ courseId: String(courseId) }),
     ]);
 
     if (!course || !viewer) {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -28,7 +28,7 @@ import { repositoryMutations, RepositoryType } from '../lib/repository/internalG
 import { assignmentMutations } from '../lib/assignment/graphql';
 import { submissionMutations } from '../lib/submission/internalGraphql';
 
-import { fromGlobalId, fromGlobalIdAsNumber, toGlobalId } from './utils';
+import { fromGlobalIdAsNumber, toGlobalId } from './utils';
 
 import { buildUnauthorizedError, getToken } from '../utils/request';
 
@@ -98,7 +98,7 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
             }
 
             const client = initOctokit(githubToken);
-            return listOpenPRs(viewer, fromGlobalId(courseId).dbId, client);
+            return listOpenPRs(viewer, String(fromGlobalIdAsNumber(courseId)), client);
           } catch (error) {
             context.logger.error('Error while fetching open pull requests', { error });
             return [];
@@ -122,7 +122,7 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
           try {
             const repositoriesFilters = {
               forUserId: String(viewer.id),
-              ...(courseId ? { forCourseId: fromGlobalId(courseId).dbId } : {}),
+              ...(courseId ? { forCourseId: String(fromGlobalIdAsNumber(courseId)) } : {}),
             };
 
             context.logger.info('Searching repositories', {
@@ -154,11 +154,11 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
         description: 'Finds a course for the viewer',
         type: CourseType,
         resolve: async (viewer, args, { logger }) => {
-          const { dbId: courseId } = fromGlobalId(args.id);
+          const courseId = fromGlobalIdAsNumber(args.id);
 
           logger.info('Finding course', { courseId });
 
-          const course = await findCourse({ courseId });
+          const course = await findCourse({ courseId: String(courseId) });
           const userRole = await findUserRoleInCourse({
             courseId: Number(courseId),
             userId: viewer.id as number,

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -72,7 +72,7 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
         resolve: s =>
           toGlobalId({
             entityName: 'viewer',
-            dbId: String(s.id),
+            dbId: s.id!,
           }),
       },
       name: { type: new GraphQLNonNull(GraphQLString) },
@@ -98,7 +98,7 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
             }
 
             const client = initOctokit(githubToken);
-            return listOpenPRs(viewer, String(fromGlobalIdAsNumber(courseId)), client);
+            return listOpenPRs(viewer, fromGlobalIdAsNumber(courseId), client);
           } catch (error) {
             context.logger.error('Error while fetching open pull requests', { error });
             return [];
@@ -121,8 +121,8 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
 
           try {
             const repositoriesFilters = {
-              forUserId: String(viewer.id),
-              ...(courseId ? { forCourseId: String(fromGlobalIdAsNumber(courseId)) } : {}),
+              forUserId: viewer.id,
+              ...(courseId ? { forCourseId: fromGlobalIdAsNumber(courseId) } : {}),
             };
 
             context.logger.info('Searching repositories', {
@@ -158,7 +158,7 @@ const ViewerType: GraphQLObjectType<UserFields, AuthenticatedContext> =
 
           logger.info('Finding course', { courseId });
 
-          const course = await findCourse({ courseId: String(courseId) });
+          const course = await findCourse({ courseId });
           const userRole = await findUserRoleInCourse({
             courseId: Number(courseId),
             userId: viewer.id as number,
@@ -234,7 +234,7 @@ const Query: GraphQLObjectType<null, Context> = new GraphQLObjectType({
           throw new Error('Invite not found');
         }
 
-        const course = await findCourse({ courseId: String(invite.courseId) });
+        const course = await findCourse({ courseId: invite.courseId });
         if (!course) {
           throw new Error('Course not found');
         }

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -19,8 +19,8 @@ export const fromGlobalIdAsNumber = (globalId: GlobalId): number => {
     throw new TypeError(`Received invalid globalId, value ${globalId}`);
   }
 
-  const [_entityName, databaseId] = Buffer.from(globalId, 'base64').toString().split(':');
-  return Number(databaseId)
-}
+  const [, databaseId] = Buffer.from(globalId, 'base64').toString().split(':');
+  return Number(databaseId);
+};
 
 export { RAArgs };

--- a/src/graphql/utils.ts
+++ b/src/graphql/utils.ts
@@ -8,22 +8,19 @@ const RAArgs = {
 };
 
 type GlobalId = string;
-type EntityPayload = { entityName: string; dbId: string };
+type EntityPayload = { entityName: string; dbId: number | string };
 
 export const toGlobalId = ({ dbId, entityName }: EntityPayload): GlobalId => {
   return Buffer.from(`${entityName}:${dbId}`).toString('base64');
 };
 
-export const fromGlobalId = (globalId: GlobalId): EntityPayload => {
+export const fromGlobalIdAsNumber = (globalId: GlobalId): number => {
   if (typeof globalId !== 'string') {
     throw new TypeError(`Received invalid globalId, value ${globalId}`);
   }
 
-  const decoded = Buffer.from(globalId, 'base64').toString().split(':');
-  return { entityName: decoded[0], dbId: decoded[1] };
-};
-
-export const fromGlobalIdAsNumber = (globalId: GlobalId): number =>
-  Number(fromGlobalId(globalId).dbId);
+  const [_entityName, databaseId] = Buffer.from(globalId, 'base64').toString().split(':');
+  return Number(databaseId)
+}
 
 export { RAArgs };

--- a/src/lib/adminUser/adminService.ts
+++ b/src/lib/adminUser/adminService.ts
@@ -33,8 +33,8 @@ const buildModelFields = (adminUser: Nullable<AdminUserModel>): AdminUserFields 
   };
 };
 
-const buildQuery = (id: string): WhereOptions<AdminUserModel> => {
-  return { id: Number(id) };
+const buildQuery = (id: number): WhereOptions<AdminUserModel> => {
+  return { id };
 };
 
 const validate = async (data: Omit<AdminUserFields, 'id'>): Promise<void> => {
@@ -62,7 +62,7 @@ export async function createAdminUser(
 }
 
 export async function updateAdminUser(
-  id: string,
+  id: number,
   data: Omit<AdminUserFields, 'id'>
 ): Promise<AdminUserFields> {
   await validate(data);
@@ -77,7 +77,7 @@ export async function countAdminUsers(): Promise<number> {
 export async function findAdminUser({
   adminUserId,
 }: {
-  adminUserId: string;
+  adminUserId: number;
 }): Promise<AdminUserFields> {
   return findModel(AdminUserModel, buildModelFields, buildQuery(adminUserId));
 }

--- a/src/lib/adminUser/graphql.ts
+++ b/src/lib/adminUser/graphql.ts
@@ -33,7 +33,7 @@ const AdminUserType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType
   fields: getFields({ isUpdate: true }),
 });
 
-const findAdminUserCallback = (id: string) => {
+const findAdminUserCallback = (id: number) => {
   return findAdminUser({ adminUserId: id });
 };
 

--- a/src/lib/assignment/assignmentService.ts
+++ b/src/lib/assignment/assignmentService.ts
@@ -61,7 +61,7 @@ export async function createAssignment(
 }
 
 export async function updateAssignment(
-  id: string,
+  id: number,
   data: AssignmentFields
 ): Promise<AssignmentFields> {
   const dataWithActiveField = {
@@ -70,9 +70,7 @@ export async function updateAssignment(
     ...omit(data, ['startDate', 'endDate']),
   };
 
-  return updateModel(AssignmentModel, dataWithActiveField, buildModelFields, {
-    id: Number(id),
-  });
+  return updateModel(AssignmentModel, dataWithActiveField, buildModelFields, { id });
 }
 
 export async function countAssignments(): Promise<number> {
@@ -96,7 +94,7 @@ export async function findAllAssignments(
 export async function findAssignment({
   assignmentId,
 }: {
-  assignmentId: string;
+  assignmentId: number;
 }): Promise<AssignmentFields> {
-  return findModel(AssignmentModel, buildModelFields, { id: Number(assignmentId) });
+  return findModel(AssignmentModel, buildModelFields, { id: assignmentId });
 }

--- a/src/lib/assignment/graphql.ts
+++ b/src/lib/assignment/graphql.ts
@@ -18,9 +18,9 @@ import {
   findAssignment,
   updateAssignment,
 } from './assignmentService';
-import { fromGlobalId, fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
+import { fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
 
-import { countSubmissions, findAllSubmissions } from '../submission/submissionsService';
+import { findAllSubmissions } from '../submission/submissionsService';
 import {
   createReviewers,
   findReviewer,
@@ -141,41 +141,6 @@ export const AssignmentType = new GraphQLObjectType({
         }
 
         return startDate < now;
-      },
-    },
-    viewerAlreadyMadeSubmission: {
-      type: new GraphQLNonNull(GraphQLBoolean),
-      description: 'Whether the viewer has already made a submission or not.',
-      resolve: async (assignment, _, context: AuthenticatedContext) => {
-        let forSubmitterId = context.viewerUserId;
-
-        if (assignment.isGroup) {
-          const [viewerCourseUserRole] = await findAllUserRoles({
-            forCourseId: assignment.courseId,
-            forUserId: context.viewerUserId,
-          });
-
-          if (!viewerCourseUserRole) {
-            throw new Error('Viewer has no role in course.');
-          }
-
-          const [viewerGroupParticipant] = await findAllGroupParticipants({
-            forAssignmentId: assignment.id,
-            forUserRoleId: viewerCourseUserRole.id,
-          });
-
-          if (!viewerGroupParticipant) {
-            // Si el viewer no es participante de ningun grupo retornamos false.
-            return false;
-          }
-
-          forSubmitterId = Number(viewerGroupParticipant.groupId);
-        }
-
-        return !!(await countSubmissions({
-          forAssignmentId: assignment.id,
-          forSubmitterId,
-        }));
       },
     },
     courseId: {
@@ -497,8 +462,8 @@ export const assignmentMutations: GraphQLFieldConfigMap<null, AuthenticatedConte
           input: { assignmentId: encodedAssignmentId, reviewers },
         } = args;
 
-        const assignmentId = fromGlobalId(encodedAssignmentId).dbId;
-        const assignment = await findAssignment({ assignmentId });
+        const assignmentId = fromGlobalIdAsNumber(encodedAssignmentId);
+        const assignment = await findAssignment({ assignmentId: String(assignmentId) });
 
         if (!assignment) {
           throw new Error('Assignment not found');

--- a/src/lib/assignment/graphql.ts
+++ b/src/lib/assignment/graphql.ts
@@ -84,7 +84,7 @@ export const AssignmentType = new GraphQLObjectType({
       type: ReviewerType,
       resolve: async (assignment, _, ctx: AuthenticatedContext) => {
         try {
-          const viewer = await findUser({ userId: String(ctx.viewerUserId) });
+          const viewer = await findUser({ userId: ctx.viewerUserId });
 
           if (!viewer) {
             throw new Error('Viewer is not authenticated.');
@@ -443,7 +443,7 @@ export const assignmentMutations: GraphQLFieldConfigMap<null, AuthenticatedConte
       const { id } = args;
       const fixedId = fromGlobalIdAsNumber(id);
 
-      return await updateAssignment(String(fixedId), assignmentData);
+      return await updateAssignment(fixedId, assignmentData);
     },
   },
   // Esto vive aca porque si bien el manejo es de reviewers
@@ -463,7 +463,7 @@ export const assignmentMutations: GraphQLFieldConfigMap<null, AuthenticatedConte
         } = args;
 
         const assignmentId = fromGlobalIdAsNumber(encodedAssignmentId);
-        const assignment = await findAssignment({ assignmentId: String(assignmentId) });
+        const assignment = await findAssignment({ assignmentId: assignmentId });
 
         if (!assignment) {
           throw new Error('Assignment not found');

--- a/src/lib/assignment/internalGraphql.ts
+++ b/src/lib/assignment/internalGraphql.ts
@@ -61,7 +61,7 @@ export const InternalAssignmentType = new GraphQLObjectType({
   fields: getAssignmentFields({ addId: true }),
 });
 
-const findAssignmentCallback = (id: string): Promise<AssignmentFields> =>
+const findAssignmentCallback = (id: number): Promise<AssignmentFields> =>
   findAssignment({ assignmentId: id });
 
 const adminAssignmentsFields = buildEntityFields<AssignmentFields>({

--- a/src/lib/course/courseService.ts
+++ b/src/lib/course/courseService.ts
@@ -37,8 +37,8 @@ const buildModelFields = (course: Nullable<Course>): CourseFields => {
   };
 };
 
-const buildQuery = (id: string): WhereOptions<Course> => {
-  return { id: Number(id) };
+const buildQuery = (id: number): WhereOptions<Course> => {
+  return { id };
 };
 
 const fixData = (data: CourseFields) => {
@@ -68,7 +68,7 @@ export async function createCourse(data: CourseFields): Promise<CourseFields> {
 }
 
 export async function updateCourse(
-  id: string,
+  id: number,
   data: CourseFields
 ): Promise<CourseFields> {
   // 'id' no existe en data pero ¯\_(ツ)_/¯
@@ -84,7 +84,7 @@ export async function countCourses(): Promise<number> {
 export async function findCourse({
   courseId,
 }: {
-  courseId: string;
+  courseId: number;
 }): Promise<CourseFields> {
   return findModel(Course, buildModelFields, buildQuery(courseId));
 }

--- a/src/lib/course/graphql.ts
+++ b/src/lib/course/graphql.ts
@@ -56,7 +56,7 @@ const CourseType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   fields: getFields({ isUpdate: true }),
 });
 
-const findCourseCallback = (id: string) => {
+const findCourseCallback = (id: number) => {
   return findCourse({ courseId: id });
 };
 

--- a/src/lib/course/internalGraphql.ts
+++ b/src/lib/course/internalGraphql.ts
@@ -27,7 +27,7 @@ import {
   isTeacherRole,
 } from '../role/roleService';
 
-import { fromGlobalId, fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
+import { fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
 
 import type { CourseFields } from './courseService';
 import { findCourse, updateCourse } from './courseService';
@@ -190,9 +190,9 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
             const { assignmentId } = args;
 
             if (assignmentId) {
-              const { dbId: fixedAssignmentId } = fromGlobalId(args.assignmentId);
+              const fixedAssignmentId = fromGlobalIdAsNumber(args.assignmentId);
               const assignment = await findAssignment({
-                assignmentId: fixedAssignmentId,
+                assignmentId: String(fixedAssignmentId),
               });
               if (isDefinedAndNotEmpty(assignment)) return [assignment];
               return [];
@@ -208,11 +208,11 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
           description: 'Finds an assignment for a specific course',
           type: AssignmentType,
           resolve: async (_, args, { logger }) => {
-            const { dbId: assignmentId } = fromGlobalId(args.id);
+            const assignmentId = fromGlobalIdAsNumber(args.id);
 
             logger.info('Finding assignment', { assignmentId });
 
-            return await findAssignment({ assignmentId });
+            return await findAssignment({ assignmentId: String(assignmentId) });
           },
         },
         submission: {
@@ -297,7 +297,7 @@ export const courseMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
       // @ts-expect-error: FIXME
       const { organizationName, courseId: encodedCourseId } = args;
 
-      const { dbId: courseId } = fromGlobalId(encodedCourseId);
+      const courseId = fromGlobalIdAsNumber(encodedCourseId);
 
       const availableOrganizations = await getGithubUserOrganizationNames(token);
 
@@ -312,11 +312,11 @@ export const courseMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
       );
 
       const courseFields = {
-        ...(await findCourse({ courseId })),
+        ...(await findCourse({ courseId: String(courseId) })),
         organization: organizationName,
       };
 
-      return await updateCourse(courseId, courseFields);
+      return await updateCourse(String(courseId), courseFields);
     },
   },
 };

--- a/src/lib/course/internalGraphql.ts
+++ b/src/lib/course/internalGraphql.ts
@@ -63,7 +63,7 @@ export const CoursePublicDataType: GraphQLObjectType<CourseFields, Authenticated
         type: new GraphQLNonNull(SubjectType),
         description: 'Subject the course belongs to',
         resolve: async ({ subjectId }) => {
-          return subjectId ? await findSubject({ subjectId: String(subjectId) }) : null;
+          return subjectId ? await findSubject({ subjectId }) : null;
         },
       },
     }),
@@ -107,7 +107,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
               courseId: course.id,
               userId: viewer.id,
             });
-            const viewerRole = await findRole({ roleId: String(userRole.roleId) });
+            const viewerRole = await findRole({ roleId: userRole.roleId! });
 
             return consolidateRoles(viewerRole);
           },
@@ -176,9 +176,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
           type: new GraphQLNonNull(SubjectType),
           description: 'Subject the course belongs to',
           resolve: async ({ subjectId }) => {
-            const subject = subjectId
-              ? await findSubject({ subjectId: String(subjectId) })
-              : null;
+            const subject = subjectId ? await findSubject({ subjectId }) : null;
             return subject;
           },
         },
@@ -192,7 +190,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
             if (assignmentId) {
               const fixedAssignmentId = fromGlobalIdAsNumber(args.assignmentId);
               const assignment = await findAssignment({
-                assignmentId: String(fixedAssignmentId),
+                assignmentId: fixedAssignmentId,
               });
               if (isDefinedAndNotEmpty(assignment)) return [assignment];
               return [];
@@ -212,7 +210,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
 
             logger.info('Finding assignment', { assignmentId });
 
-            return await findAssignment({ assignmentId: String(assignmentId) });
+            return await findAssignment({ assignmentId });
           },
         },
         submission: {
@@ -226,7 +224,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
 
             if (submission) {
               const assignment = await findAssignment({
-                assignmentId: String(submission.assignmentId),
+                assignmentId: submission.assignmentId,
               });
               return {
                 ...submission,
@@ -270,7 +268,7 @@ export const CourseType: GraphQLObjectType<CourseFields, AuthenticatedContext> =
           description: 'Groups within a course',
           resolve: async (course, _, __) => {
             return await findAllGroups({
-              forCourseId: Number(course.id),
+              forCourseId: course.id,
             });
           },
         },
@@ -312,11 +310,11 @@ export const courseMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
       );
 
       const courseFields = {
-        ...(await findCourse({ courseId: String(courseId) })),
+        ...(await findCourse({ courseId })),
         organization: organizationName,
       };
 
-      return await updateCourse(String(courseId), courseFields);
+      return await updateCourse(courseId, courseFields);
     },
   },
 };

--- a/src/lib/group/graphql.ts
+++ b/src/lib/group/graphql.ts
@@ -37,7 +37,7 @@ export const GroupType = new GraphQLObjectType({
   fields: getGroupFields({ addId: true }),
 });
 
-const findGroupCallback = (id: string): Promise<GroupFields> =>
+const findGroupCallback = (id: number): Promise<GroupFields> =>
   findGroup({ groupId: id });
 
 const adminGroupsFields = buildEntityFields<GroupFields>({

--- a/src/lib/group/internalGraphql.ts
+++ b/src/lib/group/internalGraphql.ts
@@ -23,7 +23,7 @@ export const InternalGroupType: GraphQLObjectType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'group',
-          dbId: String(s.id),
+          dbId: s.id!,
         }),
     },
     courseId: {
@@ -31,7 +31,7 @@ export const InternalGroupType: GraphQLObjectType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'course',
-          dbId: String(s.courseId),
+          dbId: s.courseId!,
         }),
     },
     usersForAssignment: {

--- a/src/lib/group/service.ts
+++ b/src/lib/group/service.ts
@@ -41,10 +41,8 @@ export async function createGroup(data: GroupFields): Promise<GroupFields> {
   return createModel(GroupModel, dataWithActiveField, buildModelFields);
 }
 
-export async function updateGroup(id: string, data: GroupFields): Promise<GroupFields> {
-  return updateModel(GroupModel, data, buildModelFields, {
-    id: Number(id),
-  });
+export async function updateGroup(id: number, data: Omit<GroupFields, 'id'>): Promise<GroupFields> {
+  return updateModel(GroupModel, data, buildModelFields, { id });
 }
 
 export async function countGroups(): Promise<number> {
@@ -63,6 +61,6 @@ export async function findAllGroups(options: FindGroupsFilter): Promise<GroupFie
   return findAllModels(GroupModel, options, buildModelFields, whereClause);
 }
 
-export async function findGroup({ groupId }: { groupId: string }): Promise<GroupFields> {
-  return findModel(GroupModel, buildModelFields, { id: Number(groupId) });
+export async function findGroup({ groupId }: { groupId: number }): Promise<GroupFields> {
+  return findModel(GroupModel, buildModelFields, { id: groupId });
 }

--- a/src/lib/groupParticipant/graphql.ts
+++ b/src/lib/groupParticipant/graphql.ts
@@ -42,7 +42,7 @@ export const GroupParticipantType = new GraphQLObjectType({
   },
 });
 
-const findGroupParticipantCallback = (id: string): Promise<GroupParticipantFields> =>
+const findGroupParticipantCallback = (id: number): Promise<GroupParticipantFields> =>
   findGroupParticipant({ groupParticipantId: id });
 
 const adminGroupParticipantsFields = buildEntityFields<GroupParticipantFields>({

--- a/src/lib/groupParticipant/internalGraphql.ts
+++ b/src/lib/groupParticipant/internalGraphql.ts
@@ -33,7 +33,7 @@ export const InternalGroupParticipantType = new GraphQLObjectType({
       resolve: s =>
         toGlobalId({
           entityName: 'groupParticipant',
-          dbId: String(s.id),
+          dbId: s.id,
         }),
     },
     assignmentId: {
@@ -41,7 +41,7 @@ export const InternalGroupParticipantType = new GraphQLObjectType({
       resolve: s =>
         toGlobalId({
           entityName: 'assignment',
-          dbId: String(s.assignmentId),
+          dbId: s.assignmentId,
         }),
     },
     userRoleId: {
@@ -49,7 +49,7 @@ export const InternalGroupParticipantType = new GraphQLObjectType({
       resolve: s =>
         toGlobalId({
           entityName: 'userRole',
-          dbId: String(s.userRoleId),
+          dbId: s.userRoleId,
         }),
     },
     user: {
@@ -57,7 +57,7 @@ export const InternalGroupParticipantType = new GraphQLObjectType({
       resolve: async participant => {
         const participantUserRole = await findUserRole({ id: participant.userRoleId });
 
-        return await findUser({ userId: String(participantUserRole.userId) });
+        return await findUser({ userId: participantUserRole.userId! });
       },
     },
     groupId: {
@@ -65,7 +65,7 @@ export const InternalGroupParticipantType = new GraphQLObjectType({
       resolve: s =>
         toGlobalId({
           entityName: 'group',
-          dbId: String(s.groupId),
+          dbId: s.groupId,
         }),
     },
     group: {
@@ -132,7 +132,7 @@ export const groupParticipantMutations: GraphQLFieldConfigMap<
 
       const userRole = await findUserRoleInCourse({
         courseId,
-        userId: Number(viewer.id),
+        userId: viewer.id,
       });
 
       context.logger.info(
@@ -332,14 +332,14 @@ const validateGroupOnCreation = async ({
     throw new Error('Group name not available');
   }
 
-  const assignment = await findAssignment({ assignmentId: String(assignmentId) });
+  const assignment = await findAssignment({ assignmentId });
   if (assignment?.isGroup !== true) {
     throw new Error('Assignment is not a group assignment');
   }
 };
 
 const validateGroupOnJoin = async ({ assignmentId }: { assignmentId: number }) => {
-  const assignment = await findAssignment({ assignmentId: String(assignmentId) });
+  const assignment = await findAssignment({ assignmentId });
   if (assignment?.isGroup !== true) {
     throw new Error('Assignment is not a group assignment');
   }

--- a/src/lib/groupParticipant/service.ts
+++ b/src/lib/groupParticipant/service.ts
@@ -51,12 +51,10 @@ export async function createGroupParticipant(
 }
 
 export async function updateGroupParticipant(
-  id: string,
-  data: GroupParticipantFields
+  id: number,
+  data: Omit<GroupParticipantFields, 'id'>
 ): Promise<GroupParticipantFields> {
-  return updateModel(GroupParticipantModel, data, buildModelFields, {
-    id: Number(id),
-  });
+  return updateModel(GroupParticipantModel, data, buildModelFields, { id });
 }
 
 export async function countGroupParticipants(): Promise<number> {
@@ -80,7 +78,7 @@ export async function findAllGroupParticipants(
 }
 
 type FindGroupParticipantFilters = {
-  groupParticipantId?: string;
+  groupParticipantId?: GroupParticipantModel['id'];
   forAssignmentId?: GroupParticipantModel['assignmentId'];
   forUserRoleId?: GroupParticipantModel['userRoleId'];
   active?: boolean;
@@ -94,7 +92,7 @@ export async function findGroupParticipant({
   const whereClause = {
     ...(forUserRoleId ? { userRoleId: forUserRoleId } : {}),
     ...(forAssignmentId ? { assignmentId: forAssignmentId } : {}),
-    ...(groupParticipantId ? { id: Number(groupParticipantId) } : {}),
+    ...(groupParticipantId ? { id: groupParticipantId } : {}),
   };
 
   return findModel(GroupParticipantModel, buildModelFields, whereClause);

--- a/src/lib/invite/internalGraphql.ts
+++ b/src/lib/invite/internalGraphql.ts
@@ -69,7 +69,7 @@ export const inviteMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
 
       context.logger.info('Using invite', { inviteId });
 
-      const invite = await InviteModel.findOne({ where: { id: Number(inviteId) } });
+      const invite = await InviteModel.findOne({ where: { id: inviteId } });
 
       if (!invite) {
         throw new Error('Invite not found');

--- a/src/lib/invite/inviteService.ts
+++ b/src/lib/invite/inviteService.ts
@@ -7,13 +7,13 @@ export const buildInvite = async ({
   roleId,
   expirationMinutes,
 }: {
-  courseId: string;
-  roleId: string;
+  courseId: number;
+  roleId: number;
   expirationMinutes?: number;
 }): Promise<InviteModel> => {
   const [role, course] = await Promise.all([
-    findRole({ roleId }),
-    findCourse({ courseId }),
+    findRole({ roleId: String(roleId) }),
+    findCourse({ courseId: String(courseId) }),
   ]);
 
   if (!role.id || !course.id) {
@@ -25,8 +25,6 @@ export const buildInvite = async ({
     : undefined;
 
   return await InviteModel.create({
-    courseId: Number(courseId),
-    roleId: Number(roleId),
-    expiresAt: expiresAt,
+    courseId, roleId, expiresAt: expiresAt,
   });
 };

--- a/src/lib/invite/inviteService.ts
+++ b/src/lib/invite/inviteService.ts
@@ -12,8 +12,8 @@ export const buildInvite = async ({
   expirationMinutes?: number;
 }): Promise<InviteModel> => {
   const [role, course] = await Promise.all([
-    findRole({ roleId: String(roleId) }),
-    findCourse({ courseId: String(courseId) }),
+    findRole({ roleId }),
+    findCourse({ courseId }),
   ]);
 
   if (!role.id || !course.id) {
@@ -25,6 +25,8 @@ export const buildInvite = async ({
     : undefined;
 
   return await InviteModel.create({
-    courseId, roleId, expiresAt: expiresAt,
+    courseId,
+    roleId,
+    expiresAt: expiresAt,
   });
 };

--- a/src/lib/repository/graphql.ts
+++ b/src/lib/repository/graphql.ts
@@ -52,7 +52,7 @@ export const InternalRepositoryType = new GraphQLObjectType({
   fields: getRepositoryFields({ addId: true }),
 });
 
-const findRepositoryCallback = (id: string): Promise<RepositoryFields> =>
+const findRepositoryCallback = (id: number): Promise<RepositoryFields> =>
   findRepository({ repositoryId: id });
 
 const adminRepositoriesFields = buildEntityFields<RepositoryFields>({

--- a/src/lib/repository/internalGraphql.ts
+++ b/src/lib/repository/internalGraphql.ts
@@ -58,7 +58,7 @@ export const RepositoryType = new GraphQLObjectType({
       resolve: s => {
         return toGlobalId({
           entityName: 'repository',
-          dbId: String(s.id),
+          dbId: s.id,
         });
       },
     },

--- a/src/lib/repository/service.ts
+++ b/src/lib/repository/service.ts
@@ -35,9 +35,9 @@ const buildModelFields = (repository: Nullable<RepositoryModel>): RepositoryFiel
 
 type FindRepositoriesFilter = OrderingOptions & {
   active?: boolean;
-  forUserId?: string;
-  forGroupId?: string;
-  forCourseId?: string;
+  forUserId?: number;
+  forGroupId?: number;
+  forCourseId?: number;
 };
 
 export async function createRepository(
@@ -65,8 +65,8 @@ export async function bulkCreateRepository(
 }
 
 export async function updateRepository(
-  id: string,
-  data: RepositoryFields
+  id: number,
+  data: Omit<RepositoryFields, 'id'>
 ): Promise<RepositoryFields> {
   return updateModel(RepositoryModel, data, buildModelFields, {
     id: Number(id),

--- a/src/lib/repository/service.ts
+++ b/src/lib/repository/service.ts
@@ -95,7 +95,7 @@ export async function findAllRepositories(
 export async function findRepository({
   repositoryId,
 }: {
-  repositoryId: string;
+  repositoryId: number;
 }): Promise<RepositoryFields> {
-  return findModel(RepositoryModel, buildModelFields, { id: Number(repositoryId) });
+  return findModel(RepositoryModel, buildModelFields, { id: repositoryId });
 }

--- a/src/lib/review/graphql.ts
+++ b/src/lib/review/graphql.ts
@@ -55,7 +55,7 @@ export const ReviewType = new GraphQLObjectType({
   },
 });
 
-const findReviewCallback = (id: string): Promise<ReviewFields> =>
+const findReviewCallback = (id: number): Promise<ReviewFields> =>
   findReview({ reviewId: id });
 
 const adminReviewsFields = buildEntityFields<ReviewFields>({

--- a/src/lib/review/internalGraphql.ts
+++ b/src/lib/review/internalGraphql.ts
@@ -33,7 +33,7 @@ export const InternalReviewType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'review',
-          dbId: String(s.id),
+          dbId: s.id!,
         }),
     },
     submissionId: {
@@ -41,7 +41,7 @@ export const InternalReviewType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'submission',
-          dbId: String(s.submissionId),
+          dbId: s.submissionId!,
         }),
     },
     reviewerId: {
@@ -49,7 +49,7 @@ export const InternalReviewType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'reviewer',
-          dbId: String(s.reviewerId),
+          dbId: s.reviewerId!,
         }),
     },
     reviewedAt: {
@@ -95,7 +95,7 @@ export const reviewMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
         const { id: encodedId, grade, revisionRequested } = args;
 
         const id = fromGlobalIdAsNumber(encodedId);
-        const review = await findReview({ reviewId: String(id) });
+        const review = await findReview({ reviewId: id });
         if (!isDefinedAndNotEmpty(review)) {
           throw new Error('Review not found');
         }
@@ -113,7 +113,7 @@ export const reviewMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
         };
 
         const submission = await findSubmission({
-          submissionId: Number(review.submissionId),
+          submissionId: review.submissionId!,
         });
 
         // Si la submission ya fue re-entregada (submittedAgainAt).

--- a/src/lib/review/internalGraphql.ts
+++ b/src/lib/review/internalGraphql.ts
@@ -14,7 +14,7 @@ import { findReview, updateReview } from './service';
 import { findSubmission } from '../submission/submissionsService';
 import { dateToString } from '../../utils/dates';
 import { isDefinedAndNotEmpty } from '../../utils/object';
-import { fromGlobalId, toGlobalId } from '../../graphql/utils';
+import { fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
 import { findReviewer } from '../reviewer/service';
 
 import type { ReviewFields } from './service';
@@ -94,8 +94,8 @@ export const reviewMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> 
 
         const { id: encodedId, grade, revisionRequested } = args;
 
-        const id = fromGlobalId(encodedId).dbId;
-        const review = await findReview({ reviewId: id });
+        const id = fromGlobalIdAsNumber(encodedId);
+        const review = await findReview({ reviewId: String(id) });
         if (!isDefinedAndNotEmpty(review)) {
           throw new Error('Review not found');
         }

--- a/src/lib/review/service.ts
+++ b/src/lib/review/service.ts
@@ -47,8 +47,8 @@ export async function createReview(data: ReviewFields): Promise<ReviewFields> {
 }
 
 export async function updateReview(
-  id: string,
-  data: ReviewFields
+  id: number,
+  data: Omit<ReviewFields, 'id'>
 ): Promise<ReviewFields> {
 
   return updateModel(ReviewModel, data, buildModelFields, {
@@ -74,11 +74,11 @@ export async function findReview({
   reviewId,
   submissionId,
 }: {
-  reviewId?: string;
+  reviewId?: number;
   submissionId?: number;
 }): Promise<ReviewFields> {
   return findModel(ReviewModel, buildModelFields, {
-    ...(reviewId ? { id: Number(reviewId) } : {}),
+    ...(reviewId ? { id: reviewId } : {}),
     ...(submissionId ? { submissionId: submissionId } : {}),
   });
 }

--- a/src/lib/reviewer/internalGraphql.ts
+++ b/src/lib/reviewer/internalGraphql.ts
@@ -93,7 +93,7 @@ export const ReviewerType = new GraphQLObjectType<
           throw new Error('There is no reviewer user id');
         }
 
-        return findUser({ userId: String(reviewer.reviewerUserId) });
+        return findUser({ userId: reviewer.reviewerUserId });
       },
     },
     reviewee: {
@@ -103,9 +103,9 @@ export const ReviewerType = new GraphQLObjectType<
         ctx.logger.info('Resolving reviewee for', reviewer);
 
         if (reviewer.isGroup) {
-          return findGroup({ groupId: String(reviewer.revieweeId) });
+          return findGroup({ groupId: reviewer.revieweeId });
         } else {
-          return findUser({ userId: String(reviewer.revieweeId) });
+          return findUser({ userId: reviewer.revieweeId });
         }
       },
     },

--- a/src/lib/reviewer/internalGraphql.ts
+++ b/src/lib/reviewer/internalGraphql.ts
@@ -37,7 +37,7 @@ export const ReviewerPreviewType = new GraphQLObjectType<
       resolve: s => {
         return toGlobalId({
           entityName: 'reviewer',
-          dbId: String(s.id),
+          dbId: s.id,
         });
       },
     },
@@ -49,7 +49,7 @@ export const ReviewerPreviewType = new GraphQLObjectType<
           throw new Error();
         }
 
-        const r = await findUser({ userId: String(reviewer.reviewerUserId) });
+        const r = await findUser({ userId: reviewer.reviewerUserId });
 
         return r;
       },
@@ -59,9 +59,9 @@ export const ReviewerPreviewType = new GraphQLObjectType<
       description: 'The reviewee user.',
       resolve: async reviewer => {
         if (reviewer.isGroup) {
-          return findGroup({ groupId: String(reviewer.revieweeId) });
+          return findGroup({ groupId: reviewer.revieweeId });
         } else {
-          return findUser({ userId: String(reviewer.revieweeId) });
+          return findUser({ userId: reviewer.revieweeId });
         }
       },
     },

--- a/src/lib/role/internalGraphql.ts
+++ b/src/lib/role/internalGraphql.ts
@@ -21,7 +21,7 @@ export const RoleType: GraphQLObjectType<RoleFields, Context> = new GraphQLObjec
       resolve: role => {
         return toGlobalId({
           entityName: 'role',
-          dbId: String(role.id),
+          dbId: role.id!,
         });
       },
     },
@@ -41,7 +41,7 @@ export const RoleType: GraphQLObjectType<RoleFields, Context> = new GraphQLObjec
 
         logger.info(`Resolving parent role for role ${id}`);
 
-        const parentRole = await findRole({ roleId: String(parentRoleId) });
+        const parentRole = await findRole({ roleId: parentRoleId });
 
         return parentRole;
       },

--- a/src/lib/role/roleService.ts
+++ b/src/lib/role/roleService.ts
@@ -63,8 +63,8 @@ const fixData = (data: RoleFields): RoleAttrs => {
   };
 };
 
-const buildQuery = (id: string): Sequelize.WhereOptions<RoleModel> => {
-  return { id: Number(id) };
+const buildQuery = (id: number): Sequelize.WhereOptions<RoleModel> => {
+  return { id };
 };
 
 export async function createRole(data: RoleFields): Promise<RoleFields> {
@@ -77,8 +77,8 @@ export async function createRole(data: RoleFields): Promise<RoleFields> {
   return createModel(RoleModel, fixData(dataWithActiveField), toRoleFields);
 }
 
-export async function updateRole(id: string, data: RoleFields): Promise<RoleFields> {
-  if (data.parentRoleId && id === String(data.parentRoleId)) {
+export async function updateRole(id: number, data: RoleFields): Promise<RoleFields> {
+  if (data.parentRoleId && Number(id) === Number(data.parentRoleId)) {
     throw new Error('Role cannot be parent of itself');
   }
 
@@ -95,7 +95,7 @@ export async function countRoles(): Promise<number> {
   return countModels<RoleModel>(RoleModel);
 }
 
-export async function findRole({ roleId }: { roleId: string }): Promise<RoleFields> {
+export async function findRole({ roleId }: { roleId: number }): Promise<RoleFields> {
   return findModel(RoleModel, toRoleFields, buildQuery(roleId));
 }
 
@@ -119,7 +119,7 @@ export async function consolidateRoles(
   let targetRole = role;
 
   while (targetRole.parentRoleId) {
-    const parent = await findRole({ roleId: String(role.parentRoleId) });
+    const parent = await findRole({ roleId: targetRole.parentRoleId });
 
     allPermissions.push(...(parent.permissions ? parent.permissions : []));
 

--- a/src/lib/subject/graphql.ts
+++ b/src/lib/subject/graphql.ts
@@ -33,7 +33,7 @@ export const SubjectType: GraphQLObjectType<unknown, Context> = new GraphQLObjec
   fields: getFields({ addId: true }),
 });
 
-const findSubjectCallback = (id: string) => {
+const findSubjectCallback = (id: number) => {
   return findSubject({ subjectId: id });
 };
 

--- a/src/lib/subject/internalGraphql.ts
+++ b/src/lib/subject/internalGraphql.ts
@@ -16,7 +16,7 @@ export const SubjectType = new GraphQLObjectType({
       resolve: s =>
         toGlobalId({
           entityName: 'subject',
-          dbId: String(s.id),
+          dbId: s.id,
         }),
     },
     name: { type: new GraphQLNonNull(GraphQLString) },

--- a/src/lib/subject/subjectService.ts
+++ b/src/lib/subject/subjectService.ts
@@ -29,11 +29,11 @@ const buildModelFields = (subject: Nullable<Subject>): SubjectFields => {
   };
 };
 
-const buildQuery = (id: string): Sequelize.WhereOptions<Subject> => {
-  return { id: Number(id) };
+const buildQuery = (id: number): Sequelize.WhereOptions<Subject> => {
+  return { id };
 };
 
-const validate = async (data: SubjectFields) => {
+const validate = async (data: Omit<SubjectFields, 'id'>) => {
   const codeAlreadyUsed = await existsModel(Subject, {
     code: data.code,
   });
@@ -55,8 +55,8 @@ export async function createSubject(data: SubjectFields): Promise<SubjectFields>
 }
 
 export async function updateSubject(
-  id: string,
-  data: SubjectFields
+  id: number,
+  data: Omit<SubjectFields, 'id'>
 ): Promise<SubjectFields> {
   await validate(data);
   return updateModel(Subject, data, buildModelFields, buildQuery(id));
@@ -67,7 +67,7 @@ export const countSubjects = async (): Promise<number> => countModels<Subject>(S
 export const findSubject = async ({
   subjectId,
 }: {
-  subjectId: string;
+  subjectId: number;
 }): Promise<SubjectFields> => findModel(Subject, buildModelFields, buildQuery(subjectId));
 
 export const findAllSubjects = async (

--- a/src/lib/submission/internalGraphql.ts
+++ b/src/lib/submission/internalGraphql.ts
@@ -118,7 +118,7 @@ export const SubmissionType: GraphQLObjectType = new GraphQLObjectType<
       description: 'User or group who has made the submission',
       resolve: async (submission, _, ctx) => {
         const assignment = await findAssignment({
-          assignmentId: String(submission.assignmentId),
+          assignmentId: submission.assignmentId,
         });
 
         if (!assignment) {

--- a/src/lib/submission/internalGraphql.ts
+++ b/src/lib/submission/internalGraphql.ts
@@ -9,7 +9,7 @@ import {
   GraphQLUnionType,
 } from 'graphql';
 
-import { fromGlobalId, fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
+import { fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
 import { isDefinedAndNotEmpty } from '../../utils/object';
 
 import {
@@ -79,10 +79,10 @@ export const NonExistentSubmissionType = new GraphQLObjectType<
       description: 'User or group who has not made the submission',
       resolve: async (nonExistentSubmission, _, __) => {
         if (nonExistentSubmission.isGroup) {
-          return findGroup({ groupId: String(nonExistentSubmission.submitterId) });
+          return findGroup({ groupId: nonExistentSubmission.submitterId });
         }
 
-        return findUser({ userId: String(nonExistentSubmission.submitterId) });
+        return findUser({ userId: nonExistentSubmission.submitterId });
       },
     },
   }),
@@ -99,7 +99,7 @@ export const SubmissionType: GraphQLObjectType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'submission',
-          dbId: String(s.id),
+          dbId: s.id,
         }),
     },
     description: {
@@ -110,7 +110,7 @@ export const SubmissionType: GraphQLObjectType = new GraphQLObjectType<
       resolve: s =>
         toGlobalId({
           entityName: 'assignment',
-          dbId: String(s.assignmentId),
+          dbId: s.assignmentId,
         }),
     },
     submitter: {
@@ -129,14 +129,14 @@ export const SubmissionType: GraphQLObjectType = new GraphQLObjectType<
           ctx.logger.info('Looking for grupal submission', {
             submitterId: submission.submitterId,
           });
-          const group = await findGroup({ groupId: String(submission.submitterId) });
+          const group = await findGroup({ groupId: submission.submitterId });
           if (!isDefinedAndNotEmpty(group)) {
             return group;
           }
           return { ...group, assignmentId: assignment.id };
         }
 
-        return findUser({ userId: String(submission.submitterId) });
+        return findUser({ userId: submission.submitterId });
       },
     },
     reviewer: {
@@ -201,7 +201,7 @@ export const SubmissionType: GraphQLObjectType = new GraphQLObjectType<
       type: AssignmentType,
       resolve: async (submission, _, { logger }) => {
         const assignment = await findAssignment({
-          assignmentId: String(submission.assignmentId),
+          assignmentId: submission.assignmentId,
         });
 
         logger.info('Finding assignment from sub', { assignment });
@@ -263,7 +263,7 @@ export const submissionMutations: GraphQLFieldConfigMap<null, AuthenticatedConte
         const viewer = await getViewer(ctx);
 
         const { assignmentId: encodedAssignmentId, description, pullRequestUrl } = args;
-        const { dbId: assignmentId } = fromGlobalId(encodedAssignmentId);
+        const assignmentId = fromGlobalIdAsNumber(encodedAssignmentId);
 
         if (!viewer || !viewer.id) {
           throw new Error('Viewer not found');

--- a/src/lib/submission/submissionsService.ts
+++ b/src/lib/submission/submissionsService.ts
@@ -50,7 +50,6 @@ export async function updateSubmission(
   id: number,
   data: Partial<SubmissionFields>
 ): Promise<SubmissionFields> {
-
   return updateModel(SubmissionModel, data, buildModelFields, { id });
 }
 
@@ -102,7 +101,7 @@ export async function createSubmission({
   description,
   pullRequestUrl,
 }: CreateSubmissionInput): Promise<SubmissionFields> {
-  const assignment = await findAssignment({ assignmentId: String(assignmentId) });
+  const assignment = await findAssignment({ assignmentId });
   const now = new Date();
   const startDate = assignment.startDate && new Date(assignment.startDate);
   const endDate = assignment.endDate && new Date(assignment.endDate);

--- a/src/lib/user/graphql.ts
+++ b/src/lib/user/graphql.ts
@@ -40,7 +40,7 @@ const UserType: GraphQLObjectType<unknown, Context> = new GraphQLObjectType({
   fields: getFields({ addId: true }),
 });
 
-const findUserCallback = (id: string): Promise<UserFields> => {
+const findUserCallback = (id: number): Promise<UserFields> => {
   return findUser({ userId: id });
 };
 

--- a/src/lib/user/internalGraphql.ts
+++ b/src/lib/user/internalGraphql.ts
@@ -55,7 +55,7 @@ export const UserType: GraphQLObjectType<UserFields, AuthenticatedContext> =
         resolve: s =>
           toGlobalId({
             entityName: 'user',
-            dbId: String(s.id),
+            dbId: s.id!,
           }),
       },
       name: { type: new GraphQLNonNull(GraphQLString) },
@@ -147,7 +147,7 @@ export const getViewer = async (ctx: AuthenticatedContext): Promise<UserFields> 
 
   ctx.logger.info(`Found viewer with user ID ${viewerUserId}`);
 
-  const viewer = await findUser({ userId: String(viewerUserId) });
+  const viewer = await findUser({ userId: viewerUserId });
 
   return {
     id: viewer.id,

--- a/src/lib/user/userService.ts
+++ b/src/lib/user/userService.ts
@@ -40,13 +40,13 @@ const buildQuery = ({
   id,
   githubId,
 }: {
-  id?: Optional<string>;
+  id?: number;
   githubId?: Optional<string>;
 }): WhereOptions<UserModel> => {
   let query: WhereOptions<UserModel> = {};
 
   if (id) {
-    query = { ...query, id: Number(id) };
+    query = { ...query, id };
   }
 
   if (githubId) {
@@ -70,7 +70,7 @@ export async function createUser(data: Partial<UserFields>): Promise<UserFields>
   return createModel(UserModel, dataWithActiveField, buildModelFields);
 }
 
-export const updateUser = async (id: string, data: UserFields): Promise<UserFields> => {
+export const updateUser = async (id: number, data: UserFields): Promise<UserFields> => {
   // Buscamos si algun usuario existente tiene un id diferente al usuario.
   // Es decir si el github id va a colisionar con alguien mas.
   const collidingUser = await findUserByQuery({ githubId: data.githubId });
@@ -88,7 +88,7 @@ const findUserByQuery = async (query: WhereOptions<UserModel>): Promise<UserFiel
   return findModel(UserModel, buildModelFields, query);
 };
 
-export const findUser = async ({ userId }: { userId: string }): Promise<UserFields> => {
+export const findUser = async ({ userId }: { userId: number }): Promise<UserFields> => {
   return findUserByQuery(buildQuery({ id: userId }));
 };
 
@@ -108,10 +108,9 @@ export const findUsersInCourse = async ({
 }): Promise<UserFields[]> => {
   const userRoles = await findAllUserRoles({ forCourseId: courseId });
 
-  // @ts-expect-error: FIXME
   const userIds: UserModel['id'][] = userRoles
     .map(userRole => userRole.userId)
-    .filter(x => !!x);
+    .filter((x): x is number => !!x);
 
   return findAllModels(UserModel, {}, buildModelFields, { id: { [Op.in]: userIds } });
 };

--- a/src/lib/userRole/graphql.ts
+++ b/src/lib/userRole/graphql.ts
@@ -31,7 +31,7 @@ export const UserRoleType: GraphQLObjectType<unknown, Context> = new GraphQLObje
   fields: getFields({ addId: true }),
 });
 
-const findUserRoleCallback = (id: string) => {
+const findUserRoleCallback = (id: number) => {
   return findUserRole({ id });
 };
 

--- a/src/lib/userRole/internalGraphql.ts
+++ b/src/lib/userRole/internalGraphql.ts
@@ -33,20 +33,20 @@ export const buildUserRoleType = ({
             resolve: s =>
               toGlobalId({
                 entityName: 'userRole',
-                dbId: String(s.id),
+                dbId: s.id,
               }),
           },
           active: { type: new GraphQLNonNull(GraphQLBoolean) },
           user: {
             type: new GraphQLNonNull(userType),
-            resolve: userRole => findUser({ userId: String(userRole.userId) }),
+            resolve: userRole => findUser({ userId: userRole.userId }),
           },
           role: {
             type: new GraphQLNonNull(roleType),
             resolve: async (userRole, _, context) => {
               try {
                 context.logger.info('Finding role for userRole', userRole);
-                return await findRole({ roleId: String(userRole.roleId) });
+                return await findRole({ roleId: userRole.roleId });
               } catch (e) {
                 context.logger.error(e);
                 throw e;
@@ -57,7 +57,7 @@ export const buildUserRoleType = ({
             type: new GraphQLNonNull(courseType),
             resolve: async (userRole, _, context) => {
               try {
-                const result = await findCourse({ courseId: String(userRole.courseId) });
+                const result = await findCourse({ courseId: userRole.courseId });
                 return result;
               } catch (e) {
                 context.logger.error(e);

--- a/src/lib/userRole/userRoleService.ts
+++ b/src/lib/userRole/userRoleService.ts
@@ -32,8 +32,8 @@ const buildModelFields = (userRole: Nullable<UserRoleModel>): UserRoleFields => 
   };
 };
 
-const buildQuery = (id: string): WhereOptions<UserRoleModel> => {
-  return { id: Number(id) };
+const buildQuery = (id: number): WhereOptions<UserRoleModel> => {
+  return { id };
 };
 
 export async function createUserRole(
@@ -56,7 +56,7 @@ export async function createUserRole(
 }
 
 export async function updateUserRole(
-  id: string,
+  id: number,
   data: UserRoleFields
 ): Promise<UserRoleFields> {
   return updateModel(UserRoleModel, data, buildModelFields, buildQuery(id));
@@ -66,7 +66,7 @@ export async function countUserRoles(): Promise<number> {
   return countModels<UserRoleModel>(UserRoleModel);
 }
 
-export async function findUserRole({ id }: { id: string }): Promise<UserRoleFields> {
+export async function findUserRole({ id }: { id: number }): Promise<UserRoleFields> {
   return findModel(UserRoleModel, buildModelFields, buildQuery(id));
 }
 


### PR DESCRIPTION
PR que quiero hacer hace mucho. 

Cuando empezamos a modelar los ids de la base de datos en algún momento decidimos que usar `string` era buena idea. Spoiler: no lo era. Este PR elimina mucho código de casteo y unifica tipos en `number` para base de datos.