### PR TITLE
[TH-225] Devolver `AssignmentType` después de crear submission

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -254,7 +254,7 @@ type RootMutationType {
   createReview(courseId: ID!, grade: Int, revisionRequested: Boolean!, submissionId: ID!): SubmissionType!
 
   """Creates a new submission for the viewer"""
-  createSubmission(assignmentId: ID!, courseId: ID!, pullRequestUrl: String!): SubmissionType!
+  createSubmission(assignmentId: ID!, courseId: ID!, pullRequestUrl: String!): AssignmentType
 
   """Generates an invitation code"""
   generateInviteCode(courseId: ID!, expirationMinutes: Int, roleId: ID!): String!

--- a/src/lib/submission/internalGraphql.ts
+++ b/src/lib/submission/internalGraphql.ts
@@ -15,7 +15,6 @@ import { uniq, minBy, maxBy } from 'lodash';
 import { fromGlobalIdAsNumber, toGlobalId } from '../../graphql/utils';
 
 import {
-  createSubmission,
   findSubmission,
   SubmissionFields,
   updateSubmission,
@@ -432,47 +431,6 @@ const findSubmissionReviewer = async (submission: SubmissionFields) => {
 };
 
 export const submissionMutations: GraphQLFieldConfigMap<null, AuthenticatedContext> = {
-  createSubmission: {
-    description: 'Creates a new submission for the viewer',
-    type: new GraphQLNonNull(SubmissionType),
-    args: {
-      assignmentId: {
-        type: new GraphQLNonNull(GraphQLID),
-      },
-      courseId: {
-        type: new GraphQLNonNull(GraphQLID),
-      },
-      pullRequestUrl: {
-        type: new GraphQLNonNull(GraphQLString),
-      },
-    },
-    resolve: async (_, args, ctx) => {
-      try {
-        const viewer = await getViewer(ctx);
-
-        const { assignmentId: encodedAssignmentId, pullRequestUrl } = args;
-        const assignmentId = fromGlobalIdAsNumber(encodedAssignmentId);
-
-        if (!viewer || !viewer.id) {
-          throw new Error('Viewer not found');
-        }
-
-        ctx.logger.info('Creating submission for assignment', {
-          assignmentId,
-          userId: viewer.id,
-        });
-
-        return createSubmission({
-          submitterUserId: viewer.id,
-          assignmentId: Number(assignmentId),
-          pullRequestUrl,
-        });
-      } catch (e) {
-        ctx.logger.error('Error while creating submission', { error: e });
-        throw e;
-      }
-    },
-  },
   submitSubmissionAgain: {
     description: 'Re-submits a submission for the viewer',
     args: {


### PR DESCRIPTION
Mismo patrón que veníamos usando, mismo problema. Cuando ejecutamos una mutation de creación el resultado debería retornar la entidad padre (en este casi AssginmentType)