### PR TITLE
TH-230 Handle empty groups

### DIFF
--- a/src/lib/group/service.ts
+++ b/src/lib/group/service.ts
@@ -41,6 +41,7 @@ const buildModelFields = (group: GroupModel): GroupFields => {
 type FindGroupsFilter = OrderingOptions & {
   forCourseId?: GroupModel['courseId'];
   forAssignmentId?: GroupModel['assignmentId'];
+  onlyActiveGroups?: boolean;
   active?: boolean;
   ignoreActiveFilter?: boolean;
   name?: string;
@@ -69,16 +70,20 @@ export async function countGroups(): Promise<number> {
   return countModels<GroupModel>(GroupModel);
 }
 
+/**
+ * Finds all groups that match the given filters.
+ * By default, only active groups are returned
+ * */
 export async function findAllGroups(
   options: FindGroupsFilter,
   t?: Transaction
 ): Promise<GroupFields[]> {
-  const { forCourseId, forAssignmentId, active, name, ignoreActiveFilter } = options;
+  const { forCourseId, forAssignmentId, name, onlyActiveGroups } = options;
 
   const whereClause = {
     ...(forCourseId ? { courseId: forCourseId } : {}),
     ...(forAssignmentId ? { assignmentId: forAssignmentId } : {}),
-    ...(ignoreActiveFilter ? {} : active ? { active } : { active: true }), // If no active value set, always return active groups
+    ...(onlyActiveGroups === false ? {} : { active: true }), // By default, only search active groups
     ...(name ? { name: name } : {}),
   };
 
@@ -125,7 +130,7 @@ export async function createGroupWithParticipants(
     const courseGroups = await findAllGroups(
       {
         forCourseId: courseId,
-        ignoreActiveFilter: true, // Search active or inactive groups
+        onlyActiveGroups: false,
       },
       t
     );


### PR DESCRIPTION
La solución que implemente sería:
- Cuando un alumno se une a un grupo si antes formaba parte de otro grupo se revisa si ese grupo quedo vacio y se lo marca con **active=false**
- Si se esta creando un grupo nuevo se hace algo similar, en la funcion que estaba implementada que manejaba la creacion y borrado se suma el paso de chequear los grupos previos y deshabilitarlos si hacia falta
- En la funcion de busqueda de listado de grupos se configura por defecto en **ative = false**, cosa que solo se usen los activos por defecto (hoy en dia no estemos ningun caso donde interesen los grupos inactivos si no me equivoco)

De esa manera cada vez que se busquen grupos, sea para lo que sea, solo se van a mostrar los activos (no vacios)